### PR TITLE
Add pagination & user agent

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -9,7 +9,16 @@ const duffelAPI = DuffelAPI({ token: process.env.DUFFEL_API_TOKEN || '' })
 
 const example = async () => {
   const aircraft = await duffelAPI.aircraft.get('arc_00009VMF8AhXSSRnQDI6Hi')
-  console.log(aircraft.data)
+  console.log(aircraft)
+
+  const aircraftPages = duffelAPI.aircraft.list({
+    limit: 5
+  })
+  //console.log((await aircraftPages.next()).value)
+
+  for await (const page of aircraftPages) {
+    console.log(page)
+  }
 }
 
 example()

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -1,5 +1,5 @@
 import { Client } from './Client'
-import { APIResponse } from './types'
+import { APIResponse, PaginationMeta } from './types'
 
 export class Resource {
   private client: Client
@@ -13,4 +13,9 @@ export class Resource {
     url: string,
     body?: any
   ): Promise<APIResponse<T_Response>> => this.client.request(method, url, body)
+
+  protected paginatedRequest = <T_Response = any>(
+    url: string,
+    options?: PaginationMeta
+  ): AsyncGenerator<APIResponse<T_Response>, void, unknown> => this.client.paginatedRequest(url, options)
 }

--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -1,6 +1,6 @@
-import { APIResponse } from 'types'
-import { Offers } from './OfferRequestsTypes'
+import { APIResponse, PaginationMeta } from 'types'
 import { Resource } from '../../Resource'
+import { Offers } from './OfferRequestsTypes'
 
 /**
  * To search for flights, you'll need to create an `offer request`.
@@ -19,10 +19,11 @@ export class OfferRequests extends Resource {
     this.request('GET', `air/offer_requests/${id}`)
 
   /**
-   * Retrieves a paginated list of your offer requests. The results may be returned in any order.
-   * @TODO update request with paginatedRequest
+   * Retrieves a paginated list of all aircraft. The results may be returned in any order.
+   * @param {Object} [options] - Pagination options (optional: limit, after, before)
    */
-  public list = async (): Promise<APIResponse<Offers.OfferRequest[]>> => this.request('GET', `air/offer_requests`)
+  public list = (options?: PaginationMeta): AsyncGenerator<APIResponse<Offers.OfferRequest[]>, void, unknown> =>
+    this.paginatedRequest('air/aircraft', options)
 
   /**
    * To search for flights, you'll need to create an `offer request`.

--- a/src/resources/Aircraft/Aircraft.ts
+++ b/src/resources/Aircraft/Aircraft.ts
@@ -1,4 +1,4 @@
-import { APIResponse } from 'types'
+import { APIResponse, PaginationMeta } from 'types'
 import { Resource } from '../../Resource'
 
 /** Aircraft */
@@ -13,17 +13,18 @@ export namespace Types {
   }
 }
 
-// TODO JSDOC - investigate how it works for other editors?
-// could work nicely with OpenAPI? Investigate...
-
 /** Aircraft are used to describe what passengers will fly in for a given trip */
 export class Aircraft extends Resource {
   /**
    * Retrieves an aircraft by its ID
-   * @param id Duffel's unique identifier for the aircraft
+   * @param {string} id - Duffel's unique identifier for the aircraft
    */
-  public get = async (id: string) => this.request('GET', `air/aircraft/${id}`) as APIResponse<Types.Aircraft>
+  public get = async (id: string): Promise<APIResponse<Types.Aircraft>> => this.request('GET', `air/aircraft/${id}`)
 
-  /** Retrieves a paginated list of all aircraft. The results may be returned in any order. Duffel's unique identifier for the aircraft */
-  public list = async () => this.request('GET', 'air/aircraft') as APIResponse<Types.Aircraft[]>
+  /**
+   * Retrieves a paginated list of all aircraft. The results may be returned in any order.
+   * @param {Object} [options] - Pagination options (optional: limit, after, before)
+   */
+  public list = (options?: PaginationMeta): AsyncGenerator<APIResponse<Types.Aircraft[]>, void, unknown> =>
+    this.paginatedRequest('air/aircraft', options)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 export interface PaginationMeta {
-  limit: number
-  before: string
-  after: string
+  /** The number of results to be returned in a page, between 1 and 200 (optional, default is 50) */
+  limit?: number
+  /** "Before" cursor for pagination */
+  before?: string
+  /** "After" cursor for pagination */
+  after?: string
 }
 
 export interface ApiResponseMeta {
@@ -11,7 +14,7 @@ export interface ApiResponseMeta {
 
 export interface ApiResponseError {
   code: string
-  documentation_url: string
+  documentationUrl: string
   message: string
   title: string
   type: string
@@ -19,7 +22,7 @@ export interface ApiResponseError {
 
 export interface APIResponse<T> {
   data?: T
-  meta?: ApiResponseMeta
+  meta?: ApiResponseMeta | PaginationMeta
   errors?: ApiResponseError[]
 }
 


### PR DESCRIPTION
- Adds paginated request (return a generator that can then be iterated over, see `example.ts` for usage) (see some discussion on [here](https://www.notion.so/duffel/JS-Client-Library-Research-Technical-Scoping-c84c87af4eb04c3e870be6e195baa3f1#e41c152948d346b1a6677122317deac9))
- Also adds a user agent header, as pointed out[ in the scoping doc](https://www.notion.so/duffel/JS-Client-Library-Research-Technical-Scoping-c84c87af4eb04c3e870be6e195baa3f1#56d198bc867344cd907cddb8f3984bd8).
- Clean up some TODOs and comments.

[View on Jira](https://duffel.atlassian.net/jira/software/projects/UXP/boards/16?selectedIssue=UXP-717)