### PR TITLE
[UXP-747] Fix async generator related test responses

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -12,7 +12,7 @@ const example = async () => {
   console.log(aircraft)
 
   const airlinePages = duffelAPI.airlines.list({
-    limit: 5
+    queryParams: { limit: 5 }
   })
 
   for await (const page of airlinePages) {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -67,15 +67,19 @@ export class Client {
     }
   }
 
-  async *paginatedRequest<T_Response = any>(
-    path: string,
+  async *paginatedRequest<T_Response = any>({
+    path,
+    queryParams
+  }: {
+    path: string
     queryParams?: PaginationMeta
-  ): AsyncGenerator<APIResponse<T_Response>, void, unknown> {
+  }): AsyncGenerator<APIResponse<T_Response>, void, unknown> {
     let response = await this.request('GET', path, null, queryParams)
+    yield response
 
     while (response.meta && 'after' in response.meta && response.meta.after) {
+      response = await this.request('GET', path, null, { limit: response.meta.limit, after: response.meta.after })
       yield response
-      response = await this.request('GET', path, null, response.meta)
     }
   }
 }

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -15,8 +15,11 @@ export class Resource {
     options?: Record<string, any>
   ): Promise<APIResponse<T_Response>> => this.client.request(method, url, body, options)
 
-  protected paginatedRequest = <T_Response = any>(
-    url: string,
-    options?: PaginationMeta
-  ): AsyncGenerator<APIResponse<T_Response>, void, unknown> => this.client.paginatedRequest(url, options)
+  protected paginatedRequest = <T_Response = any>({
+    path,
+    queryParams
+  }: {
+    path: string
+    queryParams?: PaginationMeta
+  }): AsyncGenerator<APIResponse<T_Response>, void, unknown> => this.client.paginatedRequest({ path, queryParams })
 }

--- a/src/booking/OfferRequests/OfferRequests.spec.ts
+++ b/src/booking/OfferRequests/OfferRequests.spec.ts
@@ -17,10 +17,9 @@ describe('OfferRequests', () => {
   })
 
   test('should get all offer requests', async () => {
-    function* testResponse() {
-      yield { data: [mockOfferRequest], meta: { limit: 50, before: 'test', after: null } }
-    }
-    nock(/(.*)/).get(`/air/offer_requests`).reply(200, testResponse)
+    nock(/(.*)/)
+      .get(`/air/offer_requests`)
+      .reply(200, { data: [mockOfferRequest], meta: { limit: 1, before: null, after: null } })
 
     const response = new OfferRequests(new Client({ token: 'mockToken' })).list()
     for await (const page of response) {

--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -22,8 +22,10 @@ export class OfferRequests extends Resource {
    * Retrieves a paginated list of all aircraft. The results may be returned in any order.
    * @param {Object} [queryParams] - Pagination options (optional: limit, after, before)
    */
-  public list = (queryParams?: PaginationMeta): AsyncGenerator<APIResponse<Offers.OfferRequest[]>, void, unknown> =>
-    this.paginatedRequest('air/offer_requests', queryParams)
+  public list = (options?: {
+    queryParams?: PaginationMeta
+  }): AsyncGenerator<APIResponse<Offers.OfferRequest[]>, void, unknown> =>
+    this.paginatedRequest({ path: 'air/offer_requests', ...options })
 
   /**
    * To search for flights, you'll need to create an `offer request`.

--- a/src/booking/Orders/Orders.ts
+++ b/src/booking/Orders/Orders.ts
@@ -1,6 +1,6 @@
 import { APIResponse, PaginationMeta } from 'types'
-import { Order, CreateOrder, ListParamsOrders } from './OrdersTypes'
 import { Resource } from '../../Resource'
+import { CreateOrder, ListParamsOrders, Order } from './OrdersTypes'
 
 export class Orders extends Resource {
   /**
@@ -14,9 +14,9 @@ export class Orders extends Resource {
    * You can optionally filter the results by the `awaiting_payment` state and sort by the `payment_required_by` date.
    * @param {Object} [queryParams] - Pagination options (optional: limit, after, before, awaiting_payment, sort)
    */
-  public list = (
+  public list = (options?: {
     queryParams?: PaginationMeta & ListParamsOrders
-  ): AsyncGenerator<APIResponse<Order[]>, void, unknown> => this.paginatedRequest('air/orders', queryParams)
+  }): AsyncGenerator<APIResponse<Order[]>, void, unknown> => this.paginatedRequest({ path: 'air/orders', ...options })
 
   /**
    * Creates a booking with an airline based on an offer.

--- a/src/supportingResources/Aircraft/Aircraft.ts
+++ b/src/supportingResources/Aircraft/Aircraft.ts
@@ -19,6 +19,8 @@ export class Aircraft extends Resource {
    * @param {Object} [queryParams] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/aircraft/get-aircraft
    */
-  public list = (queryParams?: PaginationMeta): AsyncGenerator<APIResponse<AircraftType[]>, void, unknown> =>
-    this.paginatedRequest('air/aircraft', queryParams)
+  public list = (options?: {
+    queryParams?: PaginationMeta
+  }): AsyncGenerator<APIResponse<AircraftType[]>, void, unknown> =>
+    this.paginatedRequest({ path: 'air/aircraft', ...options })
 }

--- a/src/supportingResources/Airlines/Airlines.spec.ts
+++ b/src/supportingResources/Airlines/Airlines.spec.ts
@@ -16,13 +16,11 @@ describe('airlines', () => {
   })
 
   test('should get all airlines', async () => {
-    const param = { limit: 1, after: 'test' }
-    function* testResponse() {
-      yield { data: [mockAirline], meta: { limit: 1, before: 'test', after: null } }
-    }
-    nock(/(.*)/).get('/air/airlines').query(param).reply(200, testResponse)
+    nock(/(.*)/)
+      .get(`/air/airlines?limit=1`)
+      .reply(200, { data: [mockAirline], meta: { limit: 1, before: null, after: null } })
 
-    const response = new Airlines(new Client({ token: 'mockToken' })).list({ limit: 1, after: 'test' })
+    const response = new Airlines(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
     for await (const page of response) {
       expect(page.data).toHaveLength(1)
       expect(page.data![0].id).toBe(mockAirline.id)

--- a/src/supportingResources/Airlines/Airlines.ts
+++ b/src/supportingResources/Airlines/Airlines.ts
@@ -15,9 +15,9 @@ export class Airlines extends Resource {
 
   /**
    * Retrieves a paginated list of all airlines. The results may be returned in any order.
-   * @param {Object} [options] - Pagination options (optional: limit, after, before)
+   * @param {Object} [queryParams] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/airlines/get-airlines
    */
-  public list = (queryParams?: PaginationMeta): AsyncGenerator<APIResponse<Airline[]>, void, unknown> =>
-    this.paginatedRequest('air/airlines', queryParams)
+  public list = (options?: { queryParams?: PaginationMeta }): AsyncGenerator<APIResponse<Airline[]>, void, unknown> =>
+    this.paginatedRequest({ path: 'air/airlines', ...options })
 }

--- a/src/supportingResources/Airports/Airports.spec.ts
+++ b/src/supportingResources/Airports/Airports.spec.ts
@@ -16,13 +16,11 @@ describe('airports', () => {
   })
 
   test('should get all airports', async () => {
-    const param = { limit: 1, after: 'test' }
-    function* testResponse() {
-      yield { data: [mockAirport], meta: { limit: 1, before: 'test', after: null } }
-    }
-    nock(/(.*)/).get('/air/airports').query(param).reply(200, testResponse)
+    nock(/(.*)/)
+      .get(`/air/airports?limit=1`)
+      .reply(200, { data: [mockAirport], meta: { limit: 1, before: null, after: null } })
 
-    const response = new Airports(new Client({ token: 'mockToken' })).list({ limit: 1, after: 'test' })
+    const response = new Airports(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
     for await (const page of response) {
       expect(page.data).toHaveLength(1)
       expect(page.data![0].id).toBe(mockAirport.id)

--- a/src/supportingResources/Airports/Airports.ts
+++ b/src/supportingResources/Airports/Airports.ts
@@ -19,6 +19,10 @@ export class Airports extends Resource {
    * @param {Object} [queryParams] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/airports/get-airports
    */
-  public list = (queryParams?: PaginationMeta): AsyncGenerator<APIResponse<Airport[]>, void, unknown> =>
-    this.paginatedRequest('air/airports', queryParams)
+  public list = ({
+    queryParams
+  }: {
+    queryParams?: PaginationMeta
+  }): AsyncGenerator<APIResponse<Airport[]>, void, unknown> =>
+    this.paginatedRequest({ path: 'air/airports', queryParams })
 }


### PR DESCRIPTION
I actually over-complicated the mocked responses for the `list` functions initially, and hence they didn't work properly. This PR fixes that for all already merged endpoints. 

The issue was that I was incorrectly mocking a "generator" as a response for a `request` for each individual page; whereas what should happen is that we just mock the regular API response data structure for a `request` for each individual page, and it's the `paginatedRequest` that constructs and returns the generator. Please let me know if you'd like a more detailed explanation.

The tests are currently a bit different, let me know if we want them to be more consistent or otherwise different:
- the one in `Aircraft` actually tests responses with parameters passed in and multiple pages returned
- the one in `OfferRequest` tests responses with no parameters passed in and single page returned
- the others test responses with a limit parameter passed and a single page returned

There was also a separate bug in `paginatedRequest` where sometimes the first page wasn't returned (if only a single page existed and the while loop was never entered.