### PR TITLE
Refactor: Pass an object into request rather than ordered parameters

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -20,12 +20,17 @@ export class Client {
     this.apiVersion = 'beta'
   }
 
-  public request = async <T_Response = any>(
-    method: string,
-    path: string,
-    body?: any,
+  public request = async <T_Response = any>({
+    method,
+    path,
+    body,
+    queryParams
+  }: {
+    method: string
+    path: string
+    body?: any
     queryParams?: Record<string, any>
-  ): Promise<APIResponse<T_Response>> => {
+  }): Promise<APIResponse<T_Response>> => {
     const fullPath = new URL(path, this.basePath)
     const userAgent = `Duffel/${this.apiVersion} duffel_api_javascript/${process.env.npm_package_version}`
     const headers = {
@@ -74,11 +79,15 @@ export class Client {
     path: string
     queryParams?: PaginationMeta
   }): AsyncGenerator<APIResponse<T_Response>, void, unknown> {
-    let response = await this.request('GET', path, null, queryParams)
+    let response = await this.request({ method: 'GET', path, queryParams })
     yield response
 
     while (response.meta && 'after' in response.meta && response.meta.after) {
-      response = await this.request('GET', path, null, { limit: response.meta.limit, after: response.meta.after })
+      response = await this.request({
+        method: 'GET',
+        path,
+        queryParams: { limit: response.meta.limit, after: response.meta.after }
+      })
       yield response
     }
   }

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -8,12 +8,17 @@ export class Resource {
     this.client = client
   }
 
-  protected request = async <T_Response = any>(
-    method: string,
-    url: string,
-    body?: any,
-    options?: Record<string, any>
-  ): Promise<APIResponse<T_Response>> => this.client.request(method, url, body, options)
+  protected request = async <T_Response = any>({
+    method,
+    path,
+    body,
+    queryParams
+  }: {
+    method: string
+    path: string
+    body?: any
+    queryParams?: Record<string, any>
+  }): Promise<APIResponse<T_Response>> => this.client.request({ method, path, body, queryParams })
 
   protected paginatedRequest = <T_Response = any>({
     path,

--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -16,7 +16,7 @@ export class OfferRequests extends Resource {
    * @link https:/duffel.com/docs/api/offer-requests/get-offer-request-by-id
    */
   public get = async (id: string): Promise<APIResponse<Offers.OfferRequest>> =>
-    this.request('GET', `air/offer_requests/${id}`)
+    this.request({ method: 'GET', path: `air/offer_requests/${id}` })
 
   /**
    * Retrieves a paginated list of all aircraft. The results may be returned in any order.
@@ -43,6 +43,6 @@ export class OfferRequests extends Resource {
     body: Offers.CreateOfferRequest
     queryParams?: Offers.CreateOfferQueryParameters
   }): Promise<APIResponse<Offers.OfferRequest>> => {
-    return this.request('POST', `air/offer_requests/`, body, queryParams)
+    return this.request({ method: 'POST', path: `air/offer_requests/`, body, queryParams })
   }
 }

--- a/src/booking/Offers/Offers.ts
+++ b/src/booking/Offers/Offers.ts
@@ -12,7 +12,8 @@ export class Offers extends Resource {
    * @param {string} id - Duffel's unique identifier for the offer
    * @link https:/duffel.com/docs/api/offers/get-offer-by-id
    */
-  public get = async (id: string): Promise<APIResponse<Offer>> => this.request('GET', `air/offers/${id}`)
+  public get = async (id: string): Promise<APIResponse<Offer>> =>
+    this.request({ method: 'GET', path: `air/offers/${id}` })
 
   /**
    * Retrieves a paginated list of all offers. The results may be returned in any order.

--- a/src/booking/Orders/Orders.ts
+++ b/src/booking/Orders/Orders.ts
@@ -7,7 +7,8 @@ export class Orders extends Resource {
    * Retrieves an order by its ID
    * @param {string} id - Duffel's unique identifier for the order
    */
-  public get = async (id: string): Promise<APIResponse<Order>> => this.request('GET', `air/orders/${id}`)
+  public get = async (id: string): Promise<APIResponse<Order>> =>
+    this.request({ method: 'GET', path: `air/orders/${id}` })
 
   /**
    * Retrieves a paginated list of all orders. The results may be returned in any order.
@@ -29,6 +30,6 @@ export class Orders extends Resource {
     body: CreateOrder
     queryParams?: Record<string, any>
   }): Promise<APIResponse<Order>> => {
-    return this.request('POST', `air/orders`, body, queryParams)
+    return this.request({ method: 'POST', path: `air/orders`, body, queryParams })
   }
 }

--- a/src/supportingResources/Aircraft/Aircraft.ts
+++ b/src/supportingResources/Aircraft/Aircraft.ts
@@ -12,7 +12,8 @@ export class Aircraft extends Resource {
    * @param {string} id - Duffel's unique identifier for the aircraft
    * @link https://duffel.com/docs/api/aircraft/get-aircraft-by-id
    */
-  public get = async (id: string): Promise<APIResponse<AircraftType>> => this.request('GET', `air/aircraft/${id}`)
+  public get = async (id: string): Promise<APIResponse<AircraftType>> =>
+    this.request({ method: 'GET', path: `air/aircraft/${id}` })
 
   /**
    * Retrieves a paginated list of all aircraft. The results may be returned in any order.

--- a/src/supportingResources/Airlines/Airlines.ts
+++ b/src/supportingResources/Airlines/Airlines.ts
@@ -11,7 +11,8 @@ export class Airlines extends Resource {
    * @param {string} id - Duffel's unique identifier for the airline
    * @link https://duffel.com/docs/api/airlines/get-airline-by-id
    */
-  public get = async (id: string): Promise<APIResponse<Airline>> => this.request('GET', `air/airlines/${id}`)
+  public get = async (id: string): Promise<APIResponse<Airline>> =>
+    this.request({ method: 'GET', path: `air/airlines/${id}` })
 
   /**
    * Retrieves a paginated list of all airlines. The results may be returned in any order.

--- a/src/supportingResources/Airports/Airports.ts
+++ b/src/supportingResources/Airports/Airports.ts
@@ -12,7 +12,8 @@ export class Airports extends Resource {
    * @param {string} id - Duffel's unique identifier for the airport
    * @link https://duffel.com/docs/api/airports/get-airport-by-id
    */
-  public get = async (id: string): Promise<APIResponse<Airport>> => this.request('GET', `air/airports/${id}`)
+  public get = async (id: string): Promise<APIResponse<Airport>> =>
+    this.request({ method: 'GET', path: `air/airports/${id}` })
 
   /**
    * Retrieves a paginated list of all airports. The results may be returned in any order.


### PR DESCRIPTION
Refactors `request` as discussed [here](https://github.com/duffelhq/duffel-api-javascript/pull/11#discussion_r620318080) to make it a bit more dynamic - basically passing in an object rather than ordered parameters. You can see the benefit e.g. in paginatedRequest, where we can now call `await this.request({ method: 'GET', path, queryParams})` rather than `await this.request('GET', path, null, queryParams)` because `body` is `null`. 