### PR TITLE
fix method path when answering folderQuestion

### DIFF
--- a/scripts/createMethod.mjs
+++ b/scripts/createMethod.mjs
@@ -54,7 +54,7 @@ const folderQuestion = () => {
   return new Promise((resolve) => {
     rl.question(`Where do you want to create the method? (default/root: src): `, (answer) => {
       if (answer) {
-        methodPath = path.join(__dirname, answer)
+        methodPath = path.join(__dirname, answer, methodName)
       }
       resolve(true)
     })


### PR DESCRIPTION
# What was done?
When passing a path we weren't created the Method folder, now that behaviour was fixed