### PR TITLE
Fix some inconsistencies in OrderCancellations & OrderChanges (particularly confirm)

### DIFF
--- a/src/booking/OrderCancellations/OrderCancellations.spec.ts
+++ b/src/booking/OrderCancellations/OrderCancellations.spec.ts
@@ -24,9 +24,9 @@ describe('OrderCancellations', () => {
       .post(`/air/order_cancellations/${mockOrderCancellations.id}/actions/confirm`)
       .reply(200, { data: mockOrderCancellations })
 
-    const response = await new OrderCancellations(new Client({ token: 'mockToken' })).confirm({
-      id: 'ore_00009qzZWzjDipIkqpaUAj'
-    })
+    const response = await new OrderCancellations(new Client({ token: 'mockToken' })).confirm(
+      'ore_00009qzZWzjDipIkqpaUAj'
+    )
     expect(response.data?.order_id).toBe('ord_00009hthhsUZ8W4LxQgkjo')
   })
 })

--- a/src/booking/OrderCancellations/OrderCancellations.ts
+++ b/src/booking/OrderCancellations/OrderCancellations.ts
@@ -1,5 +1,5 @@
-import { APIResponse, CreateOrderCancellations, OrderCancellationsResponse } from '../../types'
 import { Resource } from '../../Resource'
+import { APIResponse, CreateOrderCancellation, OrderCancellation } from '../../types'
 
 export class OrderCancellations extends Resource {
   /**
@@ -13,37 +13,35 @@ export class OrderCancellations extends Resource {
   }
 
   /**
+   * Retrieves an order cancellation by its ID
+   * @param {string} id - Duffel's unique identifier for the order cancellation
+   * @link https:/duffel.com/docs/api/order-cancellations/get-order-cancellation-by-id
+   */
+  public get = async (id: string): Promise<APIResponse<OrderCancellation>> =>
+    this.request({ method: 'GET', path: `${this.path}/${id}` })
+
+  /**
    * Create order cancellation
    * @description To begin the process of cancelling an order you need to create an order cancellation.
    * @param bodyParams.order_id - Duffel's unique identifier for the order
+   * @link https://duffel.com/docs/api/order-cancellations/create-order-cancellation
    */
   public create = async ({
     bodyParams,
     queryParams
   }: {
-    bodyParams: CreateOrderCancellations
+    bodyParams: CreateOrderCancellation
     queryParams?: Record<string, any>
-  }): Promise<APIResponse<OrderCancellationsResponse>> => {
+  }): Promise<APIResponse<OrderCancellation>> => {
     return this.request({ method: 'POST', path: this.path, bodyParams, queryParams })
   }
 
   /**
    * Confirm order cancellation
    * @description Once you've created a pending order cancellation, you'll know the `refund_amount` you're due to get back.
-   * @param {{
-   *     id: string
-   *     queryParams
-   *   }} {
-   *     id,
-   *     queryParams
-   *   }
+   * @param {string} id - Duffel's unique identifier for the order to cancel
+   * @link https://duffel.com/docs/api/order-cancellations/confirm-order-cancellation
    */
-  public confirm = async ({
-    id,
-    queryParams
-  }: {
-    id: string
-    queryParams?: Record<string, any>
-  }): Promise<APIResponse<OrderCancellationsResponse>> =>
-    this.request({ method: 'POST', path: `${this.path}/${id}/actions/confirm`, queryParams })
+  public confirm = async (id: string): Promise<APIResponse<OrderCancellation>> =>
+    this.request({ method: 'POST', path: `${this.path}/${id}/actions/confirm` })
 }

--- a/src/booking/OrderCancellations/OrderCancellationsTypes.ts
+++ b/src/booking/OrderCancellations/OrderCancellationsTypes.ts
@@ -1,11 +1,11 @@
-export interface CreateOrderCancellations {
+export interface CreateOrderCancellation {
   /**
    * Duffel's unique identifier for the order
    */
   order_id: string
 }
 
-export interface OrderCancellationsResponse {
+export interface OrderCancellation {
   /**
    * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) datetime that indicates when the order cancellation was confirmed
    */

--- a/src/booking/OrderCancellations/mockOrderCancellations.ts
+++ b/src/booking/OrderCancellations/mockOrderCancellations.ts
@@ -1,6 +1,6 @@
-import { OrderCancellationsResponse } from '../../types'
+import { OrderCancellation } from '../../types'
 
-export const mockOrderCancellations: OrderCancellationsResponse = {
+export const mockOrderCancellations: OrderCancellation = {
   refund_to: 'arc_bsp_cash',
   refund_currency: 'GBP',
   refund_amount: '90.80',

--- a/src/booking/OrderChanges/OrderChanges.spec.ts
+++ b/src/booking/OrderChanges/OrderChanges.spec.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { Client } from '../../Client'
-import { OrderChanges } from './OrderChanges'
 import { mockOrderChange } from './mockOrderChanges'
+import { OrderChanges } from './OrderChanges'
 
 describe('OrderChanges', () => {
   afterEach(() => {
@@ -27,7 +27,9 @@ describe('OrderChanges', () => {
   test('should confirm a pending order change', async () => {
     nock(/(.*)/).post(`/air/order_changes/${mockOrderChange.id}`).reply(200, { data: mockOrderChange })
 
-    const response = await new OrderChanges(new Client({ token: 'mockToken' })).confirm(mockOrderChange.id)
+    const response = await new OrderChanges(new Client({ token: 'mockToken' })).confirm(mockOrderChange.id, {
+      bodyParams: { payment: {} }
+    })
     expect(response.data?.id).toBe(mockOrderChange.id)
   })
 })

--- a/src/booking/OrderChanges/OrderChanges.ts
+++ b/src/booking/OrderChanges/OrderChanges.ts
@@ -1,5 +1,5 @@
-import { APIResponse, OrderChangeOfferSlice, CreateOrderChangeParameters } from '../../types'
 import { Resource } from '../../Resource'
+import { APIResponse, ConfirmOrderChangePayment, CreateOrderChangeParameters, OrderChangeOfferSlice } from '../../types'
 
 /**
  * Once you've created an order change request, and you've chosen which slices to add and remove, you'll then want to create an order change.
@@ -18,6 +18,7 @@ export class OrderChanges extends Resource {
   /**
    * To begin the process of changing an order you need to create an order change.
    * The OrderChange will contain the `selected_order_change_offer` reference of the change you wish to make to your order.
+   * @link https://duffel.com/docs/api/order-changes/create-order-change
    */
   public create = async ({
     bodyParams
@@ -28,6 +29,7 @@ export class OrderChanges extends Resource {
   /**
    * Retrieves an order change by its ID
    * @param {string} id - Duffel's unique identifier for the order change
+   * @link https://duffel.com/docs/api/order-changes/get-order-change-by-id
    */
   public get = async (id: string): Promise<APIResponse<OrderChangeOfferSlice>> =>
     this.request({ method: 'GET', path: `${this.path}/${id}` })
@@ -35,7 +37,12 @@ export class OrderChanges extends Resource {
   /**
    * Once you've created a pending order change, you'll know the change_total_amount due for the change.
    * @param {string} id - Duffel's unique identifier for the order change
+   * @param {options.bodyParams.payment} Object - The payment details to use to pay for the order change, if there is an amount to be paid. Some order changes may not need this if they instead refund an amount. In those cases, you can pass any empty object.
+   * @link https://duffel.com/docs/api/order-changes/confirm-order-change
    */
-  public confirm = async (id: string): Promise<APIResponse<OrderChangeOfferSlice>> =>
-    this.request({ method: 'POST', path: `${this.path}/${id}` })
+  public confirm = async (
+    id: string,
+    options: { bodyParams: { payment: Partial<ConfirmOrderChangePayment> } }
+  ): Promise<APIResponse<OrderChangeOfferSlice>> =>
+    this.request({ method: 'POST', path: `${this.path}/${id}`, bodyParams: options.bodyParams })
 }

--- a/src/booking/OrderChanges/OrderChangesTypes.ts
+++ b/src/booking/OrderChanges/OrderChangesTypes.ts
@@ -1,5 +1,4 @@
-import { OrderChangeOfferSlices } from '../OrderChangeOffers/OrderChangeOfferTypes'
-import { PaymentType } from '../../types'
+import { OrderChangeOfferSlices, PaymentType } from '../../types'
 
 export interface OrderChange {
   /**
@@ -98,4 +97,25 @@ export interface CreateOrderChangeParameters {
    * Duffel's unique identifier for the order change offer
    */
   selected_order_change_offer: string
+}
+
+export interface ConfirmOrderChangePayment {
+  /**
+   * The amount of the payment. This should be the same as the change_total_amount of the order change.
+   */
+
+  amount: string
+  /**
+   * The currency of the change_total_amount, as an [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code.
+   */
+  currency: string
+
+  /**
+   * The type of payment you want to use for the Order Change.
+   * If you are an IATA agent with your own agreements with airlines, in some cases, you can pay using ARC/BSP cash by specifying arc_bsp_cash.
+   * Otherwise, you must pay using your Duffel account's balance by specifying balance.
+   * In test mode, your balance is unlimited.
+   * If you're not sure which of these options applies to you, get in touch with the Duffel support team at [help@duffel.com](mailto:help@duffel.com).
+   */
+  type: PaymentType
 }

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -1,16 +1,16 @@
 import {
   Aircraft,
   Airline,
-  OfferAvailableServiceBaggageMetadata,
   CabinClass,
   DuffelPassengerGender,
   DuffelPassengerTitle,
   DuffelPassengerType,
-  PassengerIdentityDocumentType,
-  Place,
-  PlaceType,
   FlightsConditions,
-  PaymentType
+  OfferAvailableServiceBaggageMetadata,
+  PassengerIdentityDocumentType,
+  PaymentType,
+  Place,
+  PlaceType
 } from '../../types'
 
 /**
@@ -367,7 +367,7 @@ export interface OrderPayment {
    * The type of payment you want to apply to the order.
    * If you are an IATA agent with your own agreements with airlines, in some cases, you can pay using ARC/BSP cash by specifying `arc_bsp_cash`.
    * Otherwise, you must pay using your Duffel account's `balance` by specifying balance. In test mode, your balance is unlimited.
-   * If you're not sure which of these options applies to you, get in touch with the Duffel support team at help@duffel.com.
+   * If you're not sure which of these options applies to you, get in touch with the Duffel support team at [help@duffel.com](mailto:help@duffel.com).
    */
   type: PaymentType
 


### PR DESCRIPTION
[View on Jira for more context](https://duffel.atlassian.net/browse/UXP-804)

This fixes:
- confirm OrderCancellation doesn't actually accept any queryParams according to [documentation](https://duffel.com/docs/api/order-cancellations/confirm-order-cancellation)
- confirm OrderChange does actually accept bodyParams according to [documentation](https://duffel.com/docs/api/order-changes/confirm-order-change) (this may be relatively new, and also I decided not to add the "payment_intent_id" related stuff yet as it's incredibly fresh and might still change)
- I've renamed some of the types inside OrderCancellation to match more what we have elsewhere (singular, not ending with Response)
- missing `get` method for OrderCancellations added