### PR TITLE
fix: Add missing params for a couple requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@duffel/duffel-api",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/duffelhq/duffel-api-javascript.git"
@@ -14,8 +14,7 @@
     "url": "https://github.com/duffelhq/duffel-api-javascript/issues"
   },
   "files": [
-    "index.js",
-    "index.d.ts"
+    "dist"
   ],
   "author": "Duffel Technology Limited <help@duffel.com> (http://duffel.com)",
   "license": "MIT",

--- a/src/booking/Offers/Offers.spec.ts
+++ b/src/booking/Offers/Offers.spec.ts
@@ -9,10 +9,23 @@ describe('offers', () => {
   })
 
   test('should get a single offer', async () => {
-    nock(/(.*)/).get(`/air/offers/${mockOffer.id}`).reply(200, { data: mockOffer })
+    nock(/(.*)/)
+      .get(`/air/offers/${mockOffer.id}`)
+      .reply(200, { data: { ...mockOffer, available_services: [] } })
 
     const response = await new Offers(new Client({ token: 'mockToken' })).get(mockOffer.id)
     expect(response.data?.id).toBe(mockOffer.id)
+    expect(response.data?.available_services).toHaveLength(0)
+  })
+
+  test('should get a single offer with available services', async () => {
+    nock(/(.*)/).get(`/air/offers/${mockOffer.id}?return_available_services=true`).reply(200, { data: mockOffer })
+
+    const response = await new Offers(new Client({ token: 'mockToken' })).get(mockOffer.id, {
+      queryParams: { return_available_services: true }
+    })
+    expect(response.data?.id).toBe(mockOffer.id)
+    expect(response.data?.available_services).toHaveLength(1)
   })
 
   test('should get all offers', async () => {

--- a/src/booking/Offers/Offers.ts
+++ b/src/booking/Offers/Offers.ts
@@ -1,5 +1,5 @@
-import { APIResponse, Offer, PaginationMeta } from '../../types'
 import { Resource } from '../../Resource'
+import { APIResponse, Offer, PaginationMeta } from '../../types'
 
 /**
  * Each offer represents flights you can buy from an airline at a particular price that meet your search criteria.
@@ -20,10 +20,14 @@ export class Offers extends Resource {
   /**
    * Retrieves an offer by its ID
    * @param {string} id - Duffel's unique identifier for the offer
+   * @param {string} queryParams.return_available_services - When set to true, the offer resource returned will include all the available_services returned by the airline. If set to false, the offer resource won't include any available_services.
    * @link https:/duffel.com/docs/api/offers/get-offer-by-id
    */
-  public get = async (id: string): Promise<APIResponse<Offer>> =>
-    this.request({ method: 'GET', path: `${this.path}/${id}` })
+  public get = async (
+    id: string,
+    options?: { queryParams: { return_available_services: boolean } }
+  ): Promise<APIResponse<Offer>> =>
+    this.request({ method: 'GET', path: `${this.path}/${id}`, queryParams: options?.queryParams })
 
   /**
    * Retrieves a paginated list of all offers. The results may be returned in any order.

--- a/src/booking/SeatMaps/SeatMaps.spec.ts
+++ b/src/booking/SeatMaps/SeatMaps.spec.ts
@@ -9,9 +9,12 @@ describe('SeatMaps', () => {
   })
 
   test('should get SeatMaps', async () => {
-    nock(/(.*)/).get(`/air/seat_maps/${mockSeatMap.id}`).reply(200, { data: mockSeatMap })
+    const mockOfferId = 'off_123'
+    nock(/(.*)/).get(`/air/seat_maps?offer_id=${mockOfferId}`).reply(200, { data: mockSeatMap })
 
-    const response = await new SeatMaps(new Client({ token: 'mockToken' })).get(mockSeatMap.id)
+    const response = await new SeatMaps(new Client({ token: 'mockToken' })).get({
+      queryParams: { offer_id: mockOfferId }
+    })
     expect(response.data?.id).toBe(mockSeatMap.id)
   })
 })

--- a/src/booking/SeatMaps/SeatMaps.ts
+++ b/src/booking/SeatMaps/SeatMaps.ts
@@ -1,5 +1,5 @@
-import { APIResponse, SeatMap } from '../../types'
 import { Resource } from '../../Resource'
+import { APIResponse, SeatMap } from '../../types'
 
 export class SeatMaps extends Resource {
   /**
@@ -14,9 +14,9 @@ export class SeatMaps extends Resource {
 
   /**
    * Gets seat maps by specific parameters. At the moment we only support querying by an offer ID.
-   * @param {string} offer_id - Duffel's unique identifier for the offer
+   * @param {string} options.queryParams.offer_id - Duffel's unique identifier for the offer
    * @link https://duffel.com/docs/api/seat-maps/get-seat-maps
    */
-  public get = async (id: string): Promise<APIResponse<SeatMap>> =>
-    this.request({ method: 'GET', path: `${this.path}/${id}` })
+  public get = async (options: { queryParams: { offer_id: string } }): Promise<APIResponse<SeatMap>> =>
+    this.request({ method: 'GET', path: `${this.path}`, queryParams: options.queryParams })
 }


### PR DESCRIPTION
While writing up the [guide examples](https://www.notion.so/duffel/JS-Client-Library-Guides-c168653f674f4d768f08e8ba392702e5) I noticed two endpoints weren't 100% correct:
- we were missing optional return_available_services query param on get offer
- I'd structured the seat maps get wrong (the offer_id is a query param, you don't get seat maps by their own ID)