### PR TITLE
Fix: awaiting_payment parameter should be optional

### DIFF
--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -523,5 +523,5 @@ export interface ListParamsOrders {
   /**
    * Whether to filter orders that are awaiting payment or not. If not specified, all orders regardless of their payment state will be returned.
    */
-  awaiting_payment: boolean
+  awaiting_payment?: boolean
 }


### PR DESCRIPTION
@yoamomonstruos spotted this parameter was accidentally required in the `queryParam` for listing orders. Now marked as optional.