### PR TITLE
Rename DuffelAPI to Duffel 

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -1,20 +1,20 @@
 /* eslint-disable no-console */
 
 import dotenv from 'dotenv'
-import { DuffelAPI } from '../src/index'
+import { Duffel } from '../src/index'
 
 dotenv.config()
 
-const duffelAPI = DuffelAPI({
-  token: process.env.DUFFEL_API_TOKEN || '',
+const duffel = new Duffel({
+  token: process.env.DUFFEL_ACCESS_TOKEN || '',
   options: { debug: { verbose: true } }
 })
 
 const example = async () => {
-  const aircraft = await duffelAPI.aircraft.get('arc_00009VMF8AhXSSRnQDI6Hi')
+  const aircraft = await duffel.aircraft.get('arc_00009VMF8AhXSSRnQDI6Hi')
   console.log(aircraft)
 
-  const airlinePages = duffelAPI.airlines.list({
+  const airlinePages = duffel.airlines.list({
     queryParams: { limit: 5 }
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,18 +14,29 @@ export interface DuffelAPIClient {
   seatMaps: SeatMaps
 }
 
-export const DuffelAPI = (config: Config): DuffelAPIClient => {
-  const client = new Client(config)
+export class Duffel {
+  private client: Client
+  public aircraft: Aircraft
+  public airlines: Airlines
+  public airports: Airports
+  public offerRequests: OfferRequests
+  public offers: Offers
+  public orders: Orders
+  public orderCancellations: OrderCancellations
+  public payments: Payments
+  public seatMaps: SeatMaps
 
-  return {
-    aircraft: new Aircraft(client),
-    airlines: new Airlines(client),
-    airports: new Airports(client),
-    offerRequests: new OfferRequests(client),
-    offers: new Offers(client),
-    orders: new Orders(client),
-    orderCancellations: new OrderCancellations(client),
-    payments: new Payments(client),
-    seatMaps: new SeatMaps(client)
+  constructor(config: Config) {
+    this.client = new Client(config)
+
+    this.aircraft = new Aircraft(this.client)
+    this.airlines = new Airlines(this.client)
+    this.airports = new Airports(this.client)
+    this.offerRequests = new OfferRequests(this.client)
+    this.offers = new Offers(this.client)
+    this.orders = new Orders(this.client)
+    this.orderCancellations = new OrderCancellations(this.client)
+    this.payments = new Payments(this.client)
+    this.seatMaps = new SeatMaps(this.client)
   }
 }


### PR DESCRIPTION
As agreed on Notion and from Tom's feedback, this renames DuffelAPI to Duffel and lets you instantiate it with `new` instead. Also modified example to match.
[View on Jira](https://duffel.atlassian.net/browse/UXP-827)