### PR TITLE
Offer a simpler list method version

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -26,12 +26,13 @@ const example = async () => {
   })
   console.log(airlinePage)
 
-  const airlinePages = duffel.airlines.listWithPagination({
-    queryParams: { limit: 5 }
-  })
-
-  for await (const page of airlinePages) {
-    console.log(page)
+  try {
+    const airlines = duffel.airlines.listWithGenerator()
+    for await (const airline of airlines) {
+      console.log(airline)
+    }
+  } catch (error) {
+    console.log('Caught while generating', error)
   }
 }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-unfetch'
 import { URL, URLSearchParams } from 'url'
-import { DuffelError, DuffelResponse, PaginationMeta, SDKOptions } from './types'
+import { DuffelError, DuffelResponse, SDKOptions } from './types'
 
 export interface Config {
   token: string
@@ -98,10 +98,12 @@ export class Client {
     queryParams
   }: {
     path: string
-    queryParams?: PaginationMeta
+    queryParams: any
   }): AsyncGenerator<DuffelResponse<T_Data>, void, unknown> {
-    let response = await this.request({ method: 'GET', path, queryParams })
-    yield response
+    let response: DuffelResponse<T_Data[]> = await this.request({ method: 'GET', path, queryParams })
+    for (const item of response.data) {
+      yield { data: item }
+    }
 
     while (response.meta && 'after' in response.meta && response.meta.after) {
       response = await this.request({
@@ -109,7 +111,9 @@ export class Client {
         path,
         queryParams: { limit: response.meta.limit, after: response.meta.after }
       })
-      yield response
+      for (const item of response.data) {
+        yield { data: item }
+      }
     }
   }
 }

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -1,5 +1,5 @@
 import { Client } from './Client'
-import { DuffelResponse, PaginationMeta } from './types'
+import { DuffelResponse } from './types'
 
 export class Resource {
   private client: Client
@@ -25,6 +25,6 @@ export class Resource {
     queryParams
   }: {
     path: string
-    queryParams?: PaginationMeta
+    queryParams?: any
   }): AsyncGenerator<DuffelResponse<T_Data>, void, unknown> => this.client.paginatedRequest({ path, queryParams })
 }

--- a/src/booking/OfferRequests/OfferRequests.spec.ts
+++ b/src/booking/OfferRequests/OfferRequests.spec.ts
@@ -31,10 +31,9 @@ describe('OfferRequests', () => {
       .get(`/air/offer_requests`)
       .reply(200, { data: [mockOfferRequest], meta: { limit: 1, before: null, after: null } })
 
-    const response = new OfferRequests(new Client({ token: 'mockToken' })).listWithPagination()
+    const response = new OfferRequests(new Client({ token: 'mockToken' })).listWithGenerator()
     for await (const page of response) {
-      expect(page.data).toHaveLength(1)
-      expect(page.data![0].id).toBe(mockOfferRequest.id)
+      expect(page.data!.id).toBe(mockOfferRequest.id)
     }
   })
 

--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -42,14 +42,11 @@ export class OfferRequests extends Resource {
     this.request({ method: 'GET', path: this.path, ...options })
 
   /**
-   * Retrieves a paginated list of all offer requests. The results may be returned in any order.
-   * @param {Object} [options] - Pagination query parameters (optional: limit, after, before)
+   * Retrieves a generator of all offer requests. The results may be returned in any order.
    * @link https://duffel.com/docs/api/offer-requests/get-offer-requests
    */
-  public listWithPagination = (options?: {
-    queryParams?: PaginationMeta
-  }): AsyncGenerator<DuffelResponse<OfferRequest[]>, void, unknown> =>
-    this.paginatedRequest({ path: this.path, ...options })
+  public listWithGenerator = (): AsyncGenerator<DuffelResponse<OfferRequest>, void, unknown> =>
+    this.paginatedRequest({ path: this.path })
 
   /**
    * To search for flights, you'll need to create an `offer request`.

--- a/src/booking/Offers/Offers.spec.ts
+++ b/src/booking/Offers/Offers.spec.ts
@@ -40,13 +40,12 @@ describe('offers', () => {
 
   test('should get all offers paginated', async () => {
     nock(/(.*)/)
-      .get(`/air/offers?limit=1`)
+      .get(`/air/offers`)
       .reply(200, { data: [mockOffer], meta: { limit: 1, before: null, after: null } })
 
-    const response = new Offers(new Client({ token: 'mockToken' })).listWithPagination({ queryParams: { limit: 1 } })
+    const response = new Offers(new Client({ token: 'mockToken' })).listWithGenerator()
     for await (const page of response) {
-      expect(page.data).toHaveLength(1)
-      expect(page.data![0].id).toBe(mockOffer.id)
+      expect(page.data.id).toBe(mockOffer.id)
     }
   })
 })

--- a/src/booking/Offers/Offers.ts
+++ b/src/booking/Offers/Offers.ts
@@ -38,11 +38,9 @@ export class Offers extends Resource {
     this.request({ method: 'GET', path: this.path, ...options })
 
   /**
-   * Retrieves a paginated list of all offers. The results may be returned in any order.
-   * @param {Object} [options] - Pagination options (optional: limit, after, before)
+   * Retrieves a generator of all offers. The results may be returned in any order.
    * @link https://duffel.com/docs/api/offers/get-offers
    */
-  public listWithPagination = (options?: {
-    queryParams?: PaginationMeta
-  }): AsyncGenerator<DuffelResponse<Offer[]>, void, unknown> => this.paginatedRequest({ path: this.path, ...options })
+  public listWithGenerator = (): AsyncGenerator<DuffelResponse<Offer>, void, unknown> =>
+    this.paginatedRequest({ path: this.path })
 }

--- a/src/booking/OrderChangeOffers/OrderChangeOffers.spec.ts
+++ b/src/booking/OrderChangeOffers/OrderChangeOffers.spec.ts
@@ -30,10 +30,9 @@ describe('OrderChangeOffers', () => {
       .get(`/air/order_change_offers`)
       .reply(200, { data: [mockOrderChangeOffer], meta: { limit: 1, before: null, after: null } })
 
-    const response = new OrderChangeOffers(new Client({ token: 'mockToken' })).listWithPagination()
+    const response = new OrderChangeOffers(new Client({ token: 'mockToken' })).listWithGenerator()
     for await (const page of response) {
-      expect(page.data).toHaveLength(1)
-      expect(page.data![0].id).toBe(mockOrderChangeOffer.id)
+      expect(page.data.id).toBe(mockOrderChangeOffer.id)
     }
   })
 })

--- a/src/booking/OrderChangeOffers/OrderChangeOffers.ts
+++ b/src/booking/OrderChangeOffers/OrderChangeOffers.ts
@@ -35,11 +35,8 @@ export class OrderChangeOffers extends Resource {
     this.request({ method: 'GET', path: this.path, ...options })
 
   /**
-   * Retrieves a paginated list of all order change offers. The results may be returned in any order.
-   * @param {Object} [options] - Pagination query parameters (optional: limit, after, before)
+   * Retrieves a generator of all order change offers. The results may be returned in any order.
    */
-  public listWithPagination = (options?: {
-    queryParams?: PaginationMeta
-  }): AsyncGenerator<DuffelResponse<OrderChangeOffer[]>, void, unknown> =>
-    this.paginatedRequest({ path: this.path, ...options })
+  public listWithGenerator = (): AsyncGenerator<DuffelResponse<OrderChangeOffer>, void, unknown> =>
+    this.paginatedRequest({ path: this.path })
 }

--- a/src/booking/Orders/Orders.spec.ts
+++ b/src/booking/Orders/Orders.spec.ts
@@ -30,10 +30,9 @@ describe('Orders', () => {
       .get(`/air/orders`)
       .reply(200, { data: [mockOrder], meta: { limit: 1, before: null, after: null } })
 
-    const response = new Orders(new Client({ token: 'mockToken' })).listWithPagination()
+    const response = new Orders(new Client({ token: 'mockToken' })).listWithGenerator()
     for await (const page of response) {
-      expect(page.data).toHaveLength(1)
-      expect(page.data![0].id).toBe(mockOrder.id)
+      expect(page.data.id).toBe(mockOrder.id)
     }
   })
 

--- a/src/booking/Orders/Orders.ts
+++ b/src/booking/Orders/Orders.ts
@@ -28,15 +28,14 @@ export class Orders extends Resource {
     this.request({ method: 'GET', path: this.path, ...options })
 
   /**
-   * Retrieves a paginated list of all orders. The results may be returned in any order.
+   * Retrieves a generator of all orders. The results may be returned in any order.
    * You can optionally filter the results by the `awaiting_payment` state and sort by the `payment_required_by` date.
-   * @param {Object} [options] - Pagination query parameters (optional: limit, after, before) and other optional query parameters (awaiting_payment, sort)
+   * @param {Object} [options] - Optional query parameters: awaiting_payment, sort
    * @link https://duffel.com/docs/api/orders/get-orders
    */
-  public listWithPagination = (options?: {
-    queryParams?: PaginationMeta & ListParamsOrders
-  }): AsyncGenerator<DuffelResponse<Order[]>, void, unknown> =>
-    this.paginatedRequest({ path: 'air/orders', ...options })
+  public listWithGenerator = (options?: {
+    queryParams?: ListParamsOrders
+  }): AsyncGenerator<DuffelResponse<Order>, void, unknown> => this.paginatedRequest({ path: 'air/orders', ...options })
 
   /**
    * Creates a booking with an airline based on an offer.

--- a/src/supportingResources/Aircraft/Aircraft.spec.ts
+++ b/src/supportingResources/Aircraft/Aircraft.spec.ts
@@ -1,6 +1,5 @@
 import nock from 'nock'
 import { Client } from '../../Client'
-import { PaginationMeta } from '../../types'
 import { Aircraft } from './Aircraft'
 import { mockAircraft } from './mockAircraft'
 
@@ -27,19 +26,13 @@ describe('aircraft', () => {
   })
 
   test('should get all aircraft paginated', async () => {
-    const nextId = 'next_id'
     nock(/(.*)/)
-      .get(`/air/aircraft?limit=1`)
-      .reply(200, { data: [mockAircraft], meta: { limit: 1, before: null, after: 'test' } })
-    nock(/(.*)/)
-      .get(`/air/aircraft?limit=1&after=test`)
-      .reply(200, { data: [{ ...mockAircraft, id: nextId }], meta: { limit: 1, before: 'test', after: null } })
+      .get(`/air/aircraft`)
+      .reply(200, { data: [mockAircraft], meta: { limit: 1, before: null, after: null } })
 
-    const response = new Aircraft(new Client({ token: 'mockToken' })).listWithPagination({ queryParams: { limit: 1 } })
+    const response = new Aircraft(new Client({ token: 'mockToken' })).listWithGenerator()
     for await (const page of response) {
-      expect(page.data).toHaveLength(1)
-      const expectedId = (page.meta as PaginationMeta)?.after ? mockAircraft.id : nextId
-      expect(page.data![0].id).toBe(expectedId)
+      expect(page.data.id).toBe(mockAircraft.id)
     }
   })
 })

--- a/src/supportingResources/Aircraft/Aircraft.ts
+++ b/src/supportingResources/Aircraft/Aircraft.ts
@@ -33,12 +33,9 @@ export class Aircraft extends Resource {
     this.request({ method: 'GET', path: this.path, ...options })
 
   /**
-   * Retrieves a paginated list of all aircraft. The results may be returned in any order.
-   * @param {Object} [options] - Pagination query parameters (optional: limit, after, before)
+   * Retrieves a generator of all aircraft. The results may be returned in any order.
    * @link https://duffel.com/docs/api/aircraft/get-aircraft
    */
-  public listWithPagination = (options?: {
-    queryParams?: PaginationMeta
-  }): AsyncGenerator<DuffelResponse<AircraftType[]>, void, unknown> =>
-    this.paginatedRequest({ path: this.path, ...options })
+  public listWithGenerator = (): AsyncGenerator<DuffelResponse<AircraftType>, void, unknown> =>
+    this.paginatedRequest({ path: this.path })
 }

--- a/src/supportingResources/Airlines/Airlines.spec.ts
+++ b/src/supportingResources/Airlines/Airlines.spec.ts
@@ -27,13 +27,12 @@ describe('airlines', () => {
 
   test('should get all airlines paginated', async () => {
     nock(/(.*)/)
-      .get(`/air/airlines?limit=1`)
+      .get(`/air/airlines`)
       .reply(200, { data: [mockAirline], meta: { limit: 1, before: null, after: null } })
 
-    const response = new Airlines(new Client({ token: 'mockToken' })).listWithPagination({ queryParams: { limit: 1 } })
+    const response = new Airlines(new Client({ token: 'mockToken' })).listWithGenerator()
     for await (const page of response) {
-      expect(page.data).toHaveLength(1)
-      expect(page.data![0].id).toBe(mockAirline.id)
+      expect(page.data.id).toBe(mockAirline.id)
     }
   })
 })

--- a/src/supportingResources/Airlines/Airlines.ts
+++ b/src/supportingResources/Airlines/Airlines.ts
@@ -32,11 +32,9 @@ export class Airlines extends Resource {
     this.request({ method: 'GET', path: this.path, ...options })
 
   /**
-   * Retrieves a paginated list of all airlines. The results may be returned in any order.
-   * @param {Object} [options] - Pagination query parameters (optional: limit, after, before)
+   * Retrieves a generator of all airlines. The results may be returned in any order.
    * @link https://duffel.com/docs/api/airlines/get-airlines
    */
-  public listWithPagination = (options?: {
-    queryParams?: PaginationMeta
-  }): AsyncGenerator<DuffelResponse<Airline[]>, void, unknown> => this.paginatedRequest({ path: this.path, ...options })
+  public listWithGenerator = (): AsyncGenerator<DuffelResponse<Airline>, void, unknown> =>
+    this.paginatedRequest({ path: this.path })
 }

--- a/src/supportingResources/Airports/Airports.spec.ts
+++ b/src/supportingResources/Airports/Airports.spec.ts
@@ -27,13 +27,12 @@ describe('airports', () => {
 
   test('should get all airports paginated', async () => {
     nock(/(.*)/)
-      .get(`/air/airports?limit=1`)
+      .get(`/air/airports`)
       .reply(200, { data: [mockAirport], meta: { limit: 1, before: null, after: null } })
 
-    const response = new Airports(new Client({ token: 'mockToken' })).listWithPagination({ queryParams: { limit: 1 } })
+    const response = new Airports(new Client({ token: 'mockToken' })).listWithGenerator()
     for await (const page of response) {
-      expect(page.data).toHaveLength(1)
-      expect(page.data![0].id).toBe(mockAirport.id)
+      expect(page.data.id).toBe(mockAirport.id)
     }
   })
 })

--- a/src/supportingResources/Airports/Airports.ts
+++ b/src/supportingResources/Airports/Airports.ts
@@ -33,11 +33,9 @@ export class Airports extends Resource {
     this.request({ method: 'GET', path: this.path, ...options })
 
   /**
-   * Retrieves a paginated list of all airports. The results may be returned in any order.
-   * @param {Object} [options] - Pagination query parameters (optional: limit, after, before)
+   * Retrieves a generator of all airports. The results may be returned in any order.
    * @link https://duffel.com/docs/api/airports/get-airports
    */
-  public listWithPagination = (options?: {
-    queryParams?: PaginationMeta
-  }): AsyncGenerator<DuffelResponse<Airport[]>, void, unknown> => this.paginatedRequest({ path: this.path, ...options })
+  public listWithGenerator = (): AsyncGenerator<DuffelResponse<Airport>, void, unknown> =>
+    this.paginatedRequest({ path: this.path })
 }


### PR DESCRIPTION
See [Jira](https://duffel.atlassian.net/browse/UXP-835) & [GitHub discussion](https://github.com/orgs/duffelhq/teams/engineering/discussions/3) for more context, and [Notion guide](https://www.notion.so/duffel/JS-Client-Library-Guides-c168653f674f4d768f08e8ba392702e5#68f13da96e144578846202da19c68c9e) for some usage examples.

This has two parts, so I recommend viewing by commit:
- Rename the current `list` method to `listWithPagination`
- Add a simple `list` method that just returns a single page, no generators involved.