### PR TITLE
Un-nest debug options for the client

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -7,7 +7,7 @@ dotenv.config()
 
 const duffel = new Duffel({
   token: process.env.DUFFEL_ACCESS_TOKEN || '',
-  options: { debug: { verbose: true } }
+  debug: { verbose: true }
 })
 
 const example = async () => {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -6,20 +6,20 @@ export interface Config {
   token: string
   basePath?: string
   apiVersion?: string
-  options?: SDKOptions
+  debug?: SDKOptions
 }
 
 export class Client {
   private token: string
   private basePath: string
   private apiVersion: string
-  private options: SDKOptions | undefined
+  private debug: SDKOptions | undefined
 
-  constructor({ token, basePath, apiVersion, options }: Config) {
+  constructor({ token, basePath, apiVersion, debug }: Config) {
     this.token = token
     this.basePath = basePath || 'https://api.duffel.com'
     this.apiVersion = apiVersion || 'beta'
-    this.options = options
+    this.debug = debug
   }
 
   public request = async <T_Response = any>({
@@ -64,7 +64,7 @@ export class Client {
       })
     }
 
-    if (this.options?.debug?.verbose) {
+    if (this.debug?.verbose) {
       console.info('Endpoint: ', fullPath.href)
       console.info('Method: ', method)
       if (bodyParams) console.info('Body Parameters: ', bodyParams)

--- a/src/types/ClientType.ts
+++ b/src/types/ClientType.ts
@@ -63,10 +63,8 @@ export interface APIResponse<T> {
 }
 
 export interface SDKOptions {
-  debug?: {
-    /**
-     * If `true` it will output the path and the method called
-     */
-    verbose?: boolean
-  }
+  /**
+   * If `true` it will output the path and the method called
+   */
+  verbose?: boolean
 }


### PR DESCRIPTION
[Tim pointed out on Slack](https://duffel.slack.com/archives/C01V0AXBCQP/p1620991417020200) that the nesting of debug inside options was a bit confusing/unnecessary. I think that's fair, so this is just a small PR to un-nest `debug` config.

[View on Jira](https://duffel.atlassian.net/browse/UXP-838)

[Instructions on Notion guide](https://www.notion.so/duffel/JS-Client-Library-Guides-c168653f674f4d768f08e8ba392702e5#af99663a3e5246ba970704a33b693e33)