### PR TITLE
Refactor: Change interfaces

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -21,9 +21,7 @@ const example = async () => {
     console.log('Caught', error)
   }
 
-  const airlinePage = await duffel.airlines.list({
-    queryParams: { limit: 5 }
-  })
+  const airlinePage = await duffel.airlines.list({ limit: 5 })
   console.log(airlinePage)
 
   try {

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -11,20 +11,20 @@ export class Resource {
   protected request = async <T_Data = any>({
     method,
     path,
-    bodyParams,
-    queryParams
+    data,
+    params
   }: {
     method: string
     path: string
-    bodyParams?: any
-    queryParams?: Record<string, any>
-  }): Promise<DuffelResponse<T_Data>> => this.client.request({ method, path, bodyParams, queryParams })
+    data?: Record<string, any>
+    params?: Record<string, any>
+  }): Promise<DuffelResponse<T_Data>> => this.client.request({ method, path, data, params })
 
   protected paginatedRequest = <T_Data = any>({
     path,
-    queryParams
+    params
   }: {
     path: string
-    queryParams?: any
-  }): AsyncGenerator<DuffelResponse<T_Data>, void, unknown> => this.client.paginatedRequest({ path, queryParams })
+    params?: Record<string, any>
+  }): AsyncGenerator<DuffelResponse<T_Data>, void, unknown> => this.client.paginatedRequest({ path, params })
 }

--- a/src/booking/OfferRequests/OfferRequests.spec.ts
+++ b/src/booking/OfferRequests/OfferRequests.spec.ts
@@ -20,7 +20,7 @@ describe('OfferRequests', () => {
       .get(`/air/offer_requests?limit=1`)
       .reply(200, { data: [mockOfferRequest], meta: { limit: 1, before: null, after: null } })
 
-    const response = await new OfferRequests(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
+    const response = await new OfferRequests(new Client({ token: 'mockToken' })).list({ limit: 1 })
     expect(response.data).toHaveLength(1)
     expect(response.data[0].id).toBe(mockOfferRequest.id)
   })
@@ -39,9 +39,7 @@ describe('OfferRequests', () => {
   test('should create an offer request and return offers by default', async () => {
     nock(/(.*)/).post(`/air/offer_requests/`).query(true).reply(200, { data: mockOfferRequest })
 
-    const response = await new OfferRequests(new Client({ token: 'mockToken' })).create({
-      bodyParams: mockCreateOfferRequest
-    })
+    const response = await new OfferRequests(new Client({ token: 'mockToken' })).create(mockCreateOfferRequest)
     expect(response.data?.id).toBe(mockOfferRequest.id)
   })
 
@@ -52,8 +50,8 @@ describe('OfferRequests', () => {
     nock(/(.*)/).post(`/air/offer_requests/`).query(true).reply(200, { data: mockResponseWithoutOffer })
 
     const response = await new OfferRequests(new Client({ token: 'mockToken' })).create({
-      bodyParams: mockCreateOfferRequest,
-      queryParams: { return_offers: false }
+      ...mockCreateOfferRequest,
+      return_offers: false
     })
     expect(response.data?.offers).toBe(undefined)
     expect(response.data?.id).toBe(mockOfferRequest.id)

--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -38,8 +38,8 @@ export class OfferRequests extends Resource {
    * @param {Object} [options] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/offer-requests/get-offer-requests
    */
-  public list = (options?: { queryParams?: PaginationMeta }): Promise<DuffelResponse<OfferRequest[]>> =>
-    this.request({ method: 'GET', path: this.path, ...options })
+  public list = (options?: PaginationMeta): Promise<DuffelResponse<OfferRequest[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
 
   /**
    * Retrieves a generator of all offer requests. The results may be returned in any order.
@@ -52,18 +52,14 @@ export class OfferRequests extends Resource {
    * To search for flights, you'll need to create an `offer request`.
    * An offer request describes the passengers and where and when they want to travel (in the form of a list of `slices`).
    * It may also include additional filters (e.g. a particular cabin to travel in).
-   * @param {object} [bodyParams] - body parameters to create the offer_request
-   * @param {boolean} [queryParams.return_offers] - When set to `true`, the offer request resource returned will include all the `offers` returned by the airlines.
+   * @param {boolean} [return_offers] - When set to `true`, the offer request resource returned will include all the `offers` returned by the airlines.
    * If set to false, the offer request resource won't include any `offers`. To retrieve the associated offers later, use the List Offers endpoint, specifying the `offer_request_id`.
    * @link https://duffel.com/docs/api/offer-requests/create-offer-request
    */
-  public create = async ({
-    bodyParams,
-    queryParams = { return_offers: true }
-  }: {
-    bodyParams: CreateOfferRequest
-    queryParams?: CreateOfferRequestQueryParameters
-  }): Promise<DuffelResponse<OfferRequest>> => {
-    return this.request({ method: 'POST', path: `${this.path}/`, bodyParams, queryParams })
+  public create = async (
+    options: Partial<CreateOfferRequest & CreateOfferRequestQueryParameters>
+  ): Promise<DuffelResponse<OfferRequest>> => {
+    const { return_offers, ...data } = options
+    return this.request({ method: 'POST', path: `${this.path}/`, data, params: { return_offers } })
   }
 }

--- a/src/booking/Offers/Offers.spec.ts
+++ b/src/booking/Offers/Offers.spec.ts
@@ -22,7 +22,7 @@ describe('offers', () => {
     nock(/(.*)/).get(`/air/offers/${mockOffer.id}?return_available_services=true`).reply(200, { data: mockOffer })
 
     const response = await new Offers(new Client({ token: 'mockToken' })).get(mockOffer.id, {
-      queryParams: { return_available_services: true }
+      return_available_services: true
     })
     expect(response.data?.id).toBe(mockOffer.id)
     expect(response.data?.available_services).toHaveLength(1)
@@ -33,7 +33,7 @@ describe('offers', () => {
       .get(`/air/offers?limit=1`)
       .reply(200, { data: [mockOffer], meta: { limit: 1, before: null, after: null } })
 
-    const response = await new Offers(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
+    const response = await new Offers(new Client({ token: 'mockToken' })).list({ limit: 1 })
     expect(response.data).toHaveLength(1)
     expect(response.data[0].id).toBe(mockOffer.id)
   })

--- a/src/booking/Offers/Offers.ts
+++ b/src/booking/Offers/Offers.ts
@@ -20,22 +20,19 @@ export class Offers extends Resource {
   /**
    * Retrieves an offer by its ID
    * @param {string} id - Duffel's unique identifier for the offer
-   * @param {string} queryParams.return_available_services - When set to true, the offer resource returned will include all the available_services returned by the airline. If set to false, the offer resource won't include any available_services.
+   * @param {string} return_available_services - When set to true, the offer resource returned will include all the available_services returned by the airline. If set to false, the offer resource won't include any available_services.
    * @link https:/duffel.com/docs/api/offers/get-offer-by-id
    */
-  public get = async (
-    id: string,
-    options?: { queryParams: { return_available_services: boolean } }
-  ): Promise<DuffelResponse<Offer>> =>
-    this.request({ method: 'GET', path: `${this.path}/${id}`, queryParams: options?.queryParams })
+  public get = async (id: string, params?: { return_available_services: boolean }): Promise<DuffelResponse<Offer>> =>
+    this.request({ method: 'GET', path: `${this.path}/${id}`, params })
 
   /**
    * Retrieves a page of offers. The results may be returned in any order.
    * @param {Object} [options] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/offers/get-offers
    */
-  public list = (options?: { queryParams?: PaginationMeta }): Promise<DuffelResponse<Offer[]>> =>
-    this.request({ method: 'GET', path: this.path, ...options })
+  public list = (options?: PaginationMeta): Promise<DuffelResponse<Offer[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
 
   /**
    * Retrieves a generator of all offers. The results may be returned in any order.

--- a/src/booking/OrderCancellations/OrderCancellations.spec.ts
+++ b/src/booking/OrderCancellations/OrderCancellations.spec.ts
@@ -12,9 +12,7 @@ describe('OrderCancellations', () => {
     nock(/(.*)/).post(`/air/order_cancellations`).reply(200, { data: mockOrderCancellations })
 
     const response = await new OrderCancellations(new Client({ token: 'mockToken' })).create({
-      bodyParams: {
-        order_id: 'ord_00009hthhsUZ8W4LxQgkjo'
-      }
+      order_id: 'ord_00009hthhsUZ8W4LxQgkjo'
     })
     expect(response.data?.order_id).toBe('ord_00009hthhsUZ8W4LxQgkjo')
   })

--- a/src/booking/OrderCancellations/OrderCancellations.ts
+++ b/src/booking/OrderCancellations/OrderCancellations.ts
@@ -23,17 +23,11 @@ export class OrderCancellations extends Resource {
   /**
    * Create order cancellation
    * @description To begin the process of cancelling an order you need to create an order cancellation.
-   * @param bodyParams.order_id - Duffel's unique identifier for the order
+   * @param order_id - Duffel's unique identifier for the order
    * @link https://duffel.com/docs/api/order-cancellations/create-order-cancellation
    */
-  public create = async ({
-    bodyParams,
-    queryParams
-  }: {
-    bodyParams: CreateOrderCancellation
-    queryParams?: Record<string, any>
-  }): Promise<DuffelResponse<OrderCancellation>> => {
-    return this.request({ method: 'POST', path: this.path, bodyParams, queryParams })
+  public create = async (options: CreateOrderCancellation): Promise<DuffelResponse<OrderCancellation>> => {
+    return this.request({ method: 'POST', path: this.path, data: options })
   }
 
   /**

--- a/src/booking/OrderChangeOffers/OrderChangeOffers.spec.ts
+++ b/src/booking/OrderChangeOffers/OrderChangeOffers.spec.ts
@@ -20,7 +20,7 @@ describe('OrderChangeOffers', () => {
       .get(`/air/order_change_offers?limit=1`)
       .reply(200, { data: [mockOrderChangeOffer], meta: { limit: 1, before: null, after: null } })
 
-    const response = await new OrderChangeOffers(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
+    const response = await new OrderChangeOffers(new Client({ token: 'mockToken' })).list({ limit: 1 })
     expect(response.data).toHaveLength(1)
     expect(response.data[0].id).toBe(mockOrderChangeOffer.id)
   })

--- a/src/booking/OrderChangeOffers/OrderChangeOffers.ts
+++ b/src/booking/OrderChangeOffers/OrderChangeOffers.ts
@@ -31,8 +31,8 @@ export class OrderChangeOffers extends Resource {
    * Retrieves a page of order change offers. The results may be returned in any order.
    * @param {Object} [options] - Pagination options (optional: limit, after, before)
    */
-  public list = (options?: { queryParams?: PaginationMeta }): Promise<DuffelResponse<OrderChangeOffer[]>> =>
-    this.request({ method: 'GET', path: this.path, ...options })
+  public list = (options?: PaginationMeta): Promise<DuffelResponse<OrderChangeOffer[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
 
   /**
    * Retrieves a generator of all order change offers. The results may be returned in any order.

--- a/src/booking/OrderChangeRequests/OrderChangeRequests.ts
+++ b/src/booking/OrderChangeRequests/OrderChangeRequests.ts
@@ -28,12 +28,9 @@ export class OrderChangeRequests extends Resource {
   /**
    *
    * To change flights on an existing paid order, you'll need to create an order change request.
+   * @link https://duffel.com/docs/api/order-change-requests/create-order-change-request
    * @memberof OrderChangeRequests
    */
-  public create = async ({
-    bodyParams
-  }: {
-    bodyParams: CreateOrderChangeRequest
-  }): Promise<DuffelResponse<OrderChangeRequestResponse>> =>
-    this.request({ method: 'POST', path: this.path, bodyParams })
+  public create = async (options: CreateOrderChangeRequest): Promise<DuffelResponse<OrderChangeRequestResponse>> =>
+    this.request({ method: 'POST', path: this.path, data: options })
 }

--- a/src/booking/OrderChangeRequests/OrderRequestChanges.spec.ts
+++ b/src/booking/OrderChangeRequests/OrderRequestChanges.spec.ts
@@ -1,11 +1,11 @@
 import nock from 'nock'
 import { Client } from '../../Client'
-import { OrderChangeRequests } from './OrderChangeRequests'
 import {
-  mockOrderChangeRequest,
   mockCreateChangeRequest,
+  mockOrderChangeRequest,
   mockOrderChangeRequestAltered
 } from './mockOrderChangeRequests'
+import { OrderChangeRequests } from './OrderChangeRequests'
 
 describe('OrderChangeRequests', () => {
   afterEach(() => {
@@ -24,9 +24,7 @@ describe('OrderChangeRequests', () => {
   test('should create an order change request', async () => {
     nock(/(.*)/).post(`/air/order_change_requests`).reply(200, { data: mockOrderChangeRequestAltered })
 
-    const response = await new OrderChangeRequests(new Client({ token: 'mockToken' })).create({
-      bodyParams: mockCreateChangeRequest
-    })
+    const response = await new OrderChangeRequests(new Client({ token: 'mockToken' })).create(mockCreateChangeRequest)
     expect(response.data?.slices.remove.slice_id).toBe(mockCreateChangeRequest.changes.slices.remove[0].slice_id)
     expect(response.data?.slices.add.destination.iata_code).toBe(
       mockCreateChangeRequest.changes.slices.add[0].destination

--- a/src/booking/OrderChanges/OrderChanges.spec.ts
+++ b/src/booking/OrderChanges/OrderChanges.spec.ts
@@ -19,7 +19,7 @@ describe('OrderChanges', () => {
     nock(/(.*)/).post(`/air/order_changes`).reply(200, { data: mockOrderChange })
 
     const response = await new OrderChanges(new Client({ token: 'mockToken' })).create({
-      bodyParams: { selected_order_change_offer: mockOrderChange.id }
+      selected_order_change_offer: mockOrderChange.id
     })
     expect(response.data?.id).toBe(mockOrderChange.id)
   })
@@ -27,9 +27,7 @@ describe('OrderChanges', () => {
   test('should confirm a pending order change', async () => {
     nock(/(.*)/).post(`/air/order_changes/${mockOrderChange.id}`).reply(200, { data: mockOrderChange })
 
-    const response = await new OrderChanges(new Client({ token: 'mockToken' })).confirm(mockOrderChange.id, {
-      bodyParams: { payment: {} }
-    })
+    const response = await new OrderChanges(new Client({ token: 'mockToken' })).confirm(mockOrderChange.id, {})
     expect(response.data?.id).toBe(mockOrderChange.id)
   })
 })

--- a/src/booking/OrderChanges/OrderChanges.ts
+++ b/src/booking/OrderChanges/OrderChanges.ts
@@ -25,11 +25,8 @@ export class OrderChanges extends Resource {
    * The OrderChange will contain the `selected_order_change_offer` reference of the change you wish to make to your order.
    * @link https://duffel.com/docs/api/order-changes/create-order-change
    */
-  public create = async ({
-    bodyParams
-  }: {
-    bodyParams: CreateOrderChangeParameters
-  }): Promise<DuffelResponse<OrderChangeOfferSlice>> => this.request({ method: 'POST', path: this.path, bodyParams })
+  public create = async (options: CreateOrderChangeParameters): Promise<DuffelResponse<OrderChangeOfferSlice>> =>
+    this.request({ method: 'POST', path: this.path, data: options })
 
   /**
    * Retrieves an order change by its ID
@@ -42,12 +39,12 @@ export class OrderChanges extends Resource {
   /**
    * Once you've created a pending order change, you'll know the change_total_amount due for the change.
    * @param {string} id - Duffel's unique identifier for the order change
-   * @param {options.bodyParams.payment} Object - The payment details to use to pay for the order change, if there is an amount to be paid. Some order changes may not need this if they instead refund an amount. In those cases, you can pass any empty object.
+   * @param {payment} Object - The payment details to use to pay for the order change, if there is an amount to be paid. Some order changes may not need this if they instead refund an amount. In those cases, you can pass any empty object.
    * @link https://duffel.com/docs/api/order-changes/confirm-order-change
    */
   public confirm = async (
     id: string,
-    options: { bodyParams: { payment: Partial<ConfirmOrderChangePayment> } }
+    options: Partial<ConfirmOrderChangePayment>
   ): Promise<DuffelResponse<OrderChangeOfferSlice>> =>
-    this.request({ method: 'POST', path: `${this.path}/${id}`, bodyParams: options.bodyParams })
+    this.request({ method: 'POST', path: `${this.path}/${id}`, data: options })
 }

--- a/src/booking/Orders/Orders.spec.ts
+++ b/src/booking/Orders/Orders.spec.ts
@@ -20,7 +20,7 @@ describe('Orders', () => {
       .get(`/air/orders?limit=1`)
       .reply(200, { data: [mockOrder], meta: { limit: 1, before: null, after: null } })
 
-    const response = await new Orders(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
+    const response = await new Orders(new Client({ token: 'mockToken' })).list({ limit: 1 })
     expect(response.data).toHaveLength(1)
     expect(response.data[0].id).toBe(mockOrder.id)
   })
@@ -41,9 +41,7 @@ describe('Orders', () => {
       .get(`/air/orders?awaiting_payment=true`)
       .reply(200, { data: mockOnHoldOrders, meta: { limit: 1, before: null, after: null } })
 
-    const response = await new Orders(new Client({ token: 'mockToken' })).list({
-      queryParams: { awaiting_payment: true }
-    })
+    const response = await new Orders(new Client({ token: 'mockToken' })).list({ awaiting_payment: true })
     expect(response.data).toHaveLength(2)
     expect(response.data[0].payment_status.awaiting_payment).toBe(true)
     expect(response.data[1].payment_status.awaiting_payment).toBe(true)
@@ -52,7 +50,7 @@ describe('Orders', () => {
   test('should create an order', async () => {
     nock(/(.*)/).post(`/air/orders`).query(true).reply(200, { data: mockOrder })
 
-    const response = await new Orders(new Client({ token: 'mockToken' })).create({ bodyParams: mockCreateOrderRequest })
+    const response = await new Orders(new Client({ token: 'mockToken' })).create(mockCreateOrderRequest)
     expect(response.data?.id).toBe(mockOrder.id)
   })
 })

--- a/src/booking/Orders/Orders.ts
+++ b/src/booking/Orders/Orders.ts
@@ -24,8 +24,8 @@ export class Orders extends Resource {
    * @param {Object} [options] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/orders/get-orders
    */
-  public list = (options?: { queryParams?: PaginationMeta & ListParamsOrders }): Promise<DuffelResponse<Order[]>> =>
-    this.request({ method: 'GET', path: this.path, ...options })
+  public list = async (options?: PaginationMeta & ListParamsOrders): Promise<DuffelResponse<Order[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
 
   /**
    * Retrieves a generator of all orders. The results may be returned in any order.
@@ -33,21 +33,13 @@ export class Orders extends Resource {
    * @param {Object} [options] - Optional query parameters: awaiting_payment, sort
    * @link https://duffel.com/docs/api/orders/get-orders
    */
-  public listWithGenerator = (options?: {
-    queryParams?: ListParamsOrders
-  }): AsyncGenerator<DuffelResponse<Order>, void, unknown> => this.paginatedRequest({ path: 'air/orders', ...options })
+  public listWithGenerator = (options?: ListParamsOrders): AsyncGenerator<DuffelResponse<Order>, void, unknown> =>
+    this.paginatedRequest({ path: 'air/orders', params: options })
 
   /**
    * Creates a booking with an airline based on an offer.
-   * @param {{bodyParams, queryParams}} { bodyParams, queryParams }
    */
-  public create = async ({
-    bodyParams,
-    queryParams
-  }: {
-    bodyParams: CreateOrder
-    queryParams?: Record<string, any>
-  }): Promise<DuffelResponse<Order>> => {
-    return this.request({ method: 'POST', path: this.path, bodyParams, queryParams })
+  public create = async (options: CreateOrder): Promise<DuffelResponse<Order>> => {
+    return this.request({ method: 'POST', path: this.path, data: options })
   }
 }

--- a/src/booking/Payments/Payments.spec.ts
+++ b/src/booking/Payments/Payments.spec.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { Client } from '../../Client'
-import { Payments } from './Payments'
 import { mockPayment } from './mockPayment'
+import { Payments } from './Payments'
 import { CreatePayment } from './PaymentsTypes'
 
 describe('Payments', () => {
@@ -9,13 +9,13 @@ describe('Payments', () => {
     nock.cleanAll()
   })
   test('should create a payment', async () => {
-    const bodyParams: CreatePayment = {
+    const data: CreatePayment = {
       order_id: 'ord_00003x8pVDGcS8y2AWCoWv',
       payment: { amount: '30.20', currency: 'GBP', type: 'balance' }
     }
     nock(/(.*)/).post(`/air/payments`).query(true).reply(200, { data: mockPayment })
 
-    const response = await new Payments(new Client({ token: 'mockToken' })).create({ bodyParams: bodyParams })
+    const response = await new Payments(new Client({ token: 'mockToken' })).create(data)
     expect(response.data?.id).toBe(mockPayment.id)
   })
 })

--- a/src/booking/Payments/Payments.ts
+++ b/src/booking/Payments/Payments.ts
@@ -15,16 +15,10 @@ export class Payments extends Resource {
   /**
    * Creates a payment for an existing pay later order.
    * An order can be paid for up to the time limit indicated in `payment_required_by`, after which the space held for the order will be released and you will have to create a new order.
-   * @param {string} body.order_id
-   * @param {string} body.payment
+   * @param {string} order_id
+   * @param {string} payment
    */
-  public create = async ({
-    bodyParams,
-    queryParams
-  }: {
-    bodyParams: CreatePayment
-    queryParams?: Record<string, any>
-  }): Promise<DuffelResponse<Payment>> => {
-    return this.request({ method: 'POST', path: this.path, bodyParams, queryParams })
+  public create = async (options: CreatePayment): Promise<DuffelResponse<Payment>> => {
+    return this.request({ method: 'POST', path: this.path, data: options })
   }
 }

--- a/src/booking/SeatMaps/SeatMaps.spec.ts
+++ b/src/booking/SeatMaps/SeatMaps.spec.ts
@@ -12,9 +12,7 @@ describe('SeatMaps', () => {
     const mockOfferId = 'off_123'
     nock(/(.*)/).get(`/air/seat_maps?offer_id=${mockOfferId}`).reply(200, { data: mockSeatMap })
 
-    const response = await new SeatMaps(new Client({ token: 'mockToken' })).get({
-      queryParams: { offer_id: mockOfferId }
-    })
+    const response = await new SeatMaps(new Client({ token: 'mockToken' })).get({ offer_id: mockOfferId })
     expect(response.data?.id).toBe(mockSeatMap.id)
   })
 })

--- a/src/booking/SeatMaps/SeatMaps.ts
+++ b/src/booking/SeatMaps/SeatMaps.ts
@@ -14,9 +14,9 @@ export class SeatMaps extends Resource {
 
   /**
    * Gets seat maps by specific parameters. At the moment we only support querying by an offer ID.
-   * @param {string} options.queryParams.offer_id - Duffel's unique identifier for the offer
+   * @param {string} offer_id - Duffel's unique identifier for the offer
    * @link https://duffel.com/docs/api/seat-maps/get-seat-maps
    */
-  public get = async (options: { queryParams: { offer_id: string } }): Promise<DuffelResponse<SeatMap>> =>
-    this.request({ method: 'GET', path: `${this.path}`, queryParams: options.queryParams })
+  public get = async (params: { offer_id: string }): Promise<DuffelResponse<SeatMap>> =>
+    this.request({ method: 'GET', path: `${this.path}`, params })
 }

--- a/src/supportingResources/Aircraft/Aircraft.spec.ts
+++ b/src/supportingResources/Aircraft/Aircraft.spec.ts
@@ -20,7 +20,7 @@ describe('aircraft', () => {
       .get(`/air/aircraft?limit=1`)
       .reply(200, { data: [mockAircraft], meta: { limit: 1, before: null, after: null } })
 
-    const response = await new Aircraft(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
+    const response = await new Aircraft(new Client({ token: 'mockToken' })).list({ limit: 1 })
     expect(response.data).toHaveLength(1)
     expect(response.data[0].id).toBe(mockAircraft.id)
   })

--- a/src/supportingResources/Aircraft/Aircraft.ts
+++ b/src/supportingResources/Aircraft/Aircraft.ts
@@ -29,8 +29,8 @@ export class Aircraft extends Resource {
    * @param {Object} [options] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/aircraft/get-aircraft
    */
-  public list = (options?: { queryParams?: PaginationMeta }): Promise<DuffelResponse<AircraftType[]>> =>
-    this.request({ method: 'GET', path: this.path, ...options })
+  public list = (options?: PaginationMeta): Promise<DuffelResponse<AircraftType[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
 
   /**
    * Retrieves a generator of all aircraft. The results may be returned in any order.

--- a/src/supportingResources/Airlines/Airlines.spec.ts
+++ b/src/supportingResources/Airlines/Airlines.spec.ts
@@ -20,7 +20,7 @@ describe('airlines', () => {
       .get(`/air/airlines?limit=1`)
       .reply(200, { data: [mockAirline], meta: { limit: 1, before: null, after: null } })
 
-    const response = await new Airlines(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
+    const response = await new Airlines(new Client({ token: 'mockToken' })).list({ limit: 1 })
     expect(response.data).toHaveLength(1)
     expect(response.data[0].id).toBe(mockAirline.id)
   })

--- a/src/supportingResources/Airlines/Airlines.ts
+++ b/src/supportingResources/Airlines/Airlines.ts
@@ -28,8 +28,8 @@ export class Airlines extends Resource {
    * @param {Object} [options] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/airlines/get-airlines
    */
-  public list = (options?: { queryParams?: PaginationMeta }): Promise<DuffelResponse<Airline[]>> =>
-    this.request({ method: 'GET', path: this.path, ...options })
+  public list = (options?: PaginationMeta): Promise<DuffelResponse<Airline[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
 
   /**
    * Retrieves a generator of all airlines. The results may be returned in any order.

--- a/src/supportingResources/Airports/Airports.spec.ts
+++ b/src/supportingResources/Airports/Airports.spec.ts
@@ -20,7 +20,7 @@ describe('airports', () => {
       .get(`/air/airports?limit=1`)
       .reply(200, { data: [mockAirport], meta: { limit: 1, before: null, after: null } })
 
-    const response = await new Airports(new Client({ token: 'mockToken' })).list({ queryParams: { limit: 1 } })
+    const response = await new Airports(new Client({ token: 'mockToken' })).list({ limit: 1 })
     expect(response.data).toHaveLength(1)
     expect(response.data[0].id).toBe(mockAirport.id)
   })

--- a/src/supportingResources/Airports/Airports.ts
+++ b/src/supportingResources/Airports/Airports.ts
@@ -29,8 +29,8 @@ export class Airports extends Resource {
    * @param {Object} [options] - Pagination options (optional: limit, after, before)
    * @link https://duffel.com/docs/api/airports/get-airports
    */
-  public list = (options?: { queryParams?: PaginationMeta }): Promise<DuffelResponse<Airport[]>> =>
-    this.request({ method: 'GET', path: this.path, ...options })
+  public list = (options?: PaginationMeta): Promise<DuffelResponse<Airport[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
 
   /**
    * Retrieves a generator of all airports. The results may be returned in any order.


### PR DESCRIPTION
This one needs a more detailed review, and perhaps some iteration if we're not totally happy with it (or especially if any parts feel inconsistent).

Following the discussion [here](https://github.com/orgs/duffelhq/teams/engineering/discussions/2), we're refactoring a lot of the method interfaces. I started implementing it much like in my last comment on that thread but then realised there were a couple things I didn't like about it - my first example was basically just renaming what was before `bodyParams` to `data` and `queryParams` to `params`, which didn't really solve the problem of the user needing to know too much implementation detail. My second example was still relied on positioning the arguments correctly too. So this PR tries out the blended approach, where the user can just put all the information in the same object without having to know what is what, and then the methods separate out the pieces if needed (see example in code for `create` `OfferRequest`).
- in the "inner" implementation of the client I've still renamed `bodyParams` to `data` and `queryParams` to `params`
- I've updated the [Notion guide](https://www.notion.so/duffel/JS-Client-Library-Guides-c168653f674f4d768f08e8ba392702e5) so you can look at more examples if that's easier than looking at code & tests

So from that thread the example would currently look like this:
```
duffel.offerRequests.create({ 
    slices : [{
        origin: "NYC",
        destination: "ATL",
        departure_date: "2021-06-21"
    }],
    passengers: [{ type: "adult" }],
    cabin_class: "economy"
  },
  return_offers: false,
  timeout: 100 // made up, doesn't exist yet
})
```


The general pattern for methods is currently:
- Get: Only one 'get' endpoint has more than just the ID (Offer), and SeatMap is the only one without an ID so it currently just takes params. We could consider putting the `id` inside options 🤷 
 `public get = async (id: string, options?: T) =>... `
- List: `public list = async (options?: PaginationMeta & T) =>...` (see Orders for example with extra options)
- ListWithGenerator: `public listWithGenerator = (options?: T) =>...` (see Orders, others don't take anything afaik)
- Create: `public create = async (options?: T) => ...` (see Offer Requests for example that takes both body & query param)
- Confirm: `public confirm = async (id: string, options?: T) =>...`

