### PR TITLE
Shouldn't require node 14, just 12 for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Javascript client library for the Duffel API.
 ## Prerequisites
 
 - Be part of @duffel organisation in NPM
-- Node >= 14.16.0
+- Node >= 12.22.0
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.2.4"
   },
   "engines": {
-    "node": "~14.*"
+    "node": ">=12.*"
   },
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
While Node 12 is maintained/LTS, we should allow customers to use it.