### PR TITLE
Configure Dependabot version update strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     day: sunday
     time: "09:00"
   open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary


### PR DESCRIPTION
💁 By default, Dependabot only updates a language's lock file when it updates a project's dependencies. These changes were prompted by the discussion in #84 and configure Dependabot to update the manifest file as well.

📖 https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#versioning-strategy