### PR TITLE
feat(booking): add order update operation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
           'ord_00009hthhsUZ8W4LxQgkjo',
           'ser_00009UhD4ongolulWd9123',
           'seg_00009hj8USM7Ncg31cB456',
+          'pit_00009htYpSCXrwaB9DnUm2',
           'Earhart',
           'Embraer',
           'errorMsg',

--- a/README.md
+++ b/README.md
@@ -217,6 +217,30 @@ const orderCancellationResponse = await duffel.orderCancellations.confirm(order_
 console.log(orderCancellationResponse.data.id)
 ```
 
+### Update
+
+On certain endpoints you can perform updates, such as updating an order. Usually you'll do that by passing the object ID with the object data changes.
+
+```javascript
+const orderUpdateResponse = await duffel.orders.update('ord_00009hthhsUZ8W4LxQgkjo', {
+  metadata: {
+    payment_intent_id: 'pit_00009htYpSCXrwaB9DnUm2'
+  }
+})
+
+console.log(orderUpdateResponse.data.id)
+```
+
+And if you want to clear metadata:
+
+```javascript
+const orderUpdateResponse = await duffel.orders.update('ord_00009hthhsUZ8W4LxQgkjo', {
+  metadata: {}
+})
+
+console.log(orderUpdateResponse.data.id)
+```
+
 ## Configuration
 
 ### Test and live modes

--- a/src/booking/Orders/Orders.ts
+++ b/src/booking/Orders/Orders.ts
@@ -1,5 +1,5 @@
 import { Resource } from '../../Resource'
-import { CreateOrder, DuffelResponse, ListParamsOrders, Order, PaginationMeta } from '../../types'
+import { CreateOrder, DuffelResponse, ListParamsOrders, Order, PaginationMeta, UpdateSingleOrder } from '../../types'
 
 export class Orders extends Resource {
   /**
@@ -41,5 +41,17 @@ export class Orders extends Resource {
    */
   public create = async (options: CreateOrder): Promise<DuffelResponse<Order>> => {
     return this.request({ method: 'POST', path: this.path, data: options })
+  }
+
+  /**
+   * Updates a single order
+   * @description Some order fields are updateable. Each field that can be updated is detailed in the request object.
+   * @param {string} id - Duffel's unique identifier for the order
+   * @param {Object.UpdateSingleOrder} options
+   * @example (id: 'ord_00009hthhsUZ8W4LxQgkjo', { metadata: { 'payment_intent_id': 'pit_00009htYpSCXrwaB9DnUm2' } } )
+   * @link https://duffel.com/docs/api/orders/update-order-by-id
+   */
+  public update = async (id: string, options: UpdateSingleOrder): Promise<DuffelResponse<Order>> => {
+    return this.request({ method: 'PATCH', path: `${this.path}/${id}`, data: { options } })
   }
 }

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -490,6 +490,14 @@ export interface Order {
    * In some cases, you may need to contact the Duffel support team or the airline directly.
    */
   conditions: FlightsConditions
+
+  /**
+   * Metadata contains a set of key-value pairs that you can attach to an object.
+   * It can be useful for storing additional information about the object, in a structured format.
+   * Duffel does not use this information.
+   * You should not store sensitive information in this field.
+   */
+  metadata: Record<string, string>
 }
 
 export interface CreateOrder {
@@ -534,4 +542,8 @@ export interface ListParamsOrders {
    * Whether to filter orders matching a given passenger name record (PNR)
    */
   booking_reference?: string
+}
+
+export interface UpdateSingleOrder {
+  metadata: Order['metadata']
 }

--- a/src/booking/Orders/mockOrders.ts
+++ b/src/booking/Orders/mockOrders.ts
@@ -213,6 +213,9 @@ export const mockOrder: Order = {
     id: 'aln_00001876aqC8c5umZmrRds',
     iata_code: 'BA'
   },
+  metadata: {
+    customer_prefs: 'window seat'
+  },
   live_mode: false,
   id: 'ord_00009hthhsUZ8W4LxQgkjo',
   documents: [
@@ -384,6 +387,9 @@ export const mockOnHoldOrders: Order[] = [
       id: 'arl_00009VME7DAGiJjwomhv32',
       iata_code: 'AA'
     },
+    metadata: {
+      customer_prefs: 'window seat'
+    },
     live_mode: false,
     id: 'ord_0000A6GioOO1UDbjb7nIi8',
     documents: [],
@@ -539,6 +545,9 @@ export const mockOnHoldOrders: Order[] = [
       name: 'American Airlines',
       id: 'arl_00009VME7DAGiJjwomhv32',
       iata_code: 'AA'
+    },
+    metadata: {
+      customer_prefs: 'window seat'
     },
     live_mode: false,
     id: 'ord_0000A6GiZRU4WXtdZJrivT',


### PR DESCRIPTION
Users can now update a single order by passing order id and metadata