### PR TITLE
feat(orders): enable order filtering by passenger name and booking reference

### DIFF
--- a/src/booking/Orders/Orders.spec.ts
+++ b/src/booking/Orders/Orders.spec.ts
@@ -53,4 +53,24 @@ describe('Orders', () => {
     const response = await new Orders(new Client({ token: 'mockToken' })).create(mockCreateOrderRequest)
     expect(response.data?.id).toBe(mockOrder.id)
   })
+
+  test('should get orders matching a passenger name', async () => {
+    nock(/(.*)/)
+      .get(`/air/orders?passenger_name[]=Earhart`)
+      .reply(200, { data: [mockOrder], meta: { limit: 1, before: null, after: null } })
+
+    const response = await new Orders(new Client({ token: 'mockToken' })).list({ 'passenger_name[]': ['Earhart'] })
+    expect(response.data).toHaveLength(1)
+    expect(response.data[0].passengers[0].family_name).toContain('Earhart')
+  })
+
+  test('should get orders matching a given PNR / booking reference', async () => {
+    nock(/(.*)/)
+      .get(`/air/orders?booking_reference=RZPNX8`)
+      .reply(200, { data: [mockOrder], meta: { limit: 1, before: null, after: null } })
+
+    const response = await new Orders(new Client({ token: 'mockToken' })).list({ booking_reference: 'RZPNX8' })
+    expect(response.data).toHaveLength(1)
+    expect(response.data[0].booking_reference).toBe('RZPNX8')
+  })
 })

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -524,4 +524,14 @@ export interface ListParamsOrders {
    * Whether to filter orders that are awaiting payment or not. If not specified, all orders regardless of their payment state will be returned.
    */
   awaiting_payment?: boolean
+
+  /**
+   * Whether to filter orders matching a passenger name. Partial and exact matches in given and family names will be returned.
+   */
+  'passenger_name[]'?: string[]
+
+  /**
+   * Whether to filter orders matching a given passenger name record (PNR)
+   */
+  booking_reference?: string
 }


### PR DESCRIPTION
This PR updates the client library to enable order filtering by
- passenger name - partial and exact matches will be returned
- passenger name record (PNR)
