### PR TITLE
fix(offerrequests): update create operation to receive 2 arguments

### DIFF
--- a/src/booking/OfferRequests/OfferRequests.spec.ts
+++ b/src/booking/OfferRequests/OfferRequests.spec.ts
@@ -57,8 +57,7 @@ describe('OfferRequests', () => {
       .query({ return_offers: false })
       .reply(200, { data: mockResponseWithoutOffer })
 
-    const response = await new OfferRequests(new Client({ token: 'mockToken' })).create({
-      ...mockCreateOfferRequest,
+    const response = await new OfferRequests(new Client({ token: 'mockToken' })).create(mockCreateOfferRequest, {
       return_offers: false
     })
     expect(response.data?.offers).toBe(undefined)

--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -57,14 +57,14 @@ export class OfferRequests extends Resource {
    * @link https://duffel.com/docs/api/offer-requests/create-offer-request
    */
   public create = async (
-    options: Partial<CreateOfferRequest & CreateOfferRequestQueryParameters>
+    data: CreateOfferRequest,
+    params?: CreateOfferRequestQueryParameters
   ): Promise<DuffelResponse<OfferRequest>> => {
-    const { return_offers, ...data } = options
     return this.request({
       method: 'POST',
       path: `${this.path}/`,
       data,
-      params: { ...(return_offers !== undefined && return_offers !== null && { return_offers }) }
+      params
     })
   }
 }


### PR DESCRIPTION
The customer should be able to pass data and query parameters as separate arguments