### PR TITLE
Apply security updates to development dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "typescript": "^4.4.2"
   },
   "resolutions": {
+    "ansi-regex": "^5.0.1",
     "set-value": "^4.0.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,20 +1892,10 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
-
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
💁 These changes apply [selective dependency resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/) to the versions of the `ansi-regex` and `set-value` packages. These mitigate the following security advisories:
* [CVE-2021-23440](https://github.com/advisories/GHSA-4jqc-8m5r-9rpr) (`set-value`)
* [CVE-2021-3807](https://github.com/advisories/GHSA-93q8-gq69-wqmw) (`ansi-regex`)