### PR TITLE
Fix broken HTML anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ The Duffel JavaScript client library - sometimes known as an SDK - makes it easy
 
 ## Content
 
-- [Requirements](##requirements)
-- [Installation](##installation)
-- [Usage](##usage)
-- [Configuration](##configuration)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
 - [Contributing](docs/CONTRIBUTING.md)
-- [Documentation](##documentation)
+- [Documentation](#documentation)
 
 ## Requirements
 


### PR DESCRIPTION
💁 These anchor links in the README were broken, which affects the documentation here on GitHub and also that published to npm.