### PR TITLE
feat(booking): add new fields to Order and Offer passenger data

### DIFF
--- a/src/booking/Offers/OfferTypes.ts
+++ b/src/booking/Offers/OfferTypes.ts
@@ -1,6 +1,7 @@
 import {
   CabinClass,
   FlightsConditions,
+  LoyaltyProgrammeAccount,
   PassengerIdentityDocumentType,
   Place,
   PlaceType,
@@ -243,6 +244,31 @@ export interface OfferPassenger {
    * The type of the passenger.
    */
   type?: 'adult'
+
+  /**
+   * The passenger's family name. Only `space`, `-`, `'`, and letters from the `ASCII`, `Latin-1 Supplement` and `Latin
+   * Extended-A` (with the exceptions of `Æ`, `æ`, `Ĳ`, `ĳ`, `Œ`, `œ`, `Þ`, , and `ð`) Unicode charts are accepted. All
+   * other characters will result in a validation error. The minimum length is 1 character, and the maximum is 20
+   * characters.
+   *
+   * This is only required if you're also including **Loyalty Programme Accounts**.
+   */
+  family_name?: string
+
+  /**
+   * The passenger's given name. Only `space`, `-`, `'`, and letters from the `ASCII`, `Latin-1 Supplement` and `Latin
+   * Extended-A` (with the exceptions of `Æ`, `æ`, `Ĳ`, `ĳ`, `Œ`, `œ`, `Þ`, , and `ð`) Unicode charts are accepted. All
+   * other characters will result in a validation error. The minimum length is 1 character, and the maximum is 20
+   * characters.
+   *
+   * This is only required if you're also including **Loyalty Programme Accounts**.
+   */
+  given_name?: string
+
+  /**
+   * The **Loyalty Programme Accounts** for this passenger.
+   */
+  loyalty_programme_accounts?: LoyaltyProgrammeAccount[]
 
   /**
    * The identifier for the passenger, unique within this Offer Request and across all Offer Requests.

--- a/src/booking/Offers/Offers.spec.ts
+++ b/src/booking/Offers/Offers.spec.ts
@@ -94,4 +94,19 @@ describe('offers', () => {
     })
     expect(response.data?.id).toBe('pas_00009hj8USM7Ncg31cBCL')
   })
+
+  test('should get offer passenger with loyalty programme details', async () => {
+    nock(/(.*)/)
+      .get(`/air/offers/${mockOffer.id}`)
+      .reply(200, { data: mockOffer })
+
+    const response = await new Offers(new Client({ token: 'mockToken' })).get(
+      mockOffer.id
+    )
+
+    expect(response.data.passengers[0].id).toBe('pas_00009hj8USM7Ncg31cBCL')
+    expect(response.data.passengers[0].loyalty_programme_accounts).toHaveLength(
+      1
+    )
+  })
 })

--- a/src/booking/Offers/mockOffer.ts
+++ b/src/booking/Offers/mockOffer.ts
@@ -145,6 +145,14 @@ export const mockOffer: Offer = {
       type: 'adult',
       id: 'pas_00009hj8USM7Ncg31cBCL',
       age: 14,
+      given_name: 'Carol',
+      family_name: 'Danvers',
+      loyalty_programme_accounts: [
+        {
+          account_number: '12901014',
+          airline_iata_code: 'BA',
+        },
+      ],
     },
   ],
   passenger_identity_documents_required: false,

--- a/src/booking/Orders/Orders.spec.ts
+++ b/src/booking/Orders/Orders.spec.ts
@@ -163,7 +163,7 @@ describe('Orders', () => {
       mockOrder.id
     )
 
-    expect(response.data.passengers[0].id).toBe('pas_00009hj8USM7Ncg31cBCL')
+    expect(response.data.passengers[0].id).toBe('pas_00009hj8USM7Ncg31cBCLL')
     expect(response.data.passengers[0].loyalty_programme_accounts).toHaveLength(
       1
     )

--- a/src/booking/Orders/Orders.spec.ts
+++ b/src/booking/Orders/Orders.spec.ts
@@ -153,4 +153,19 @@ describe('Orders', () => {
     ).update(mockOrder.id, { metadata })
     expect(response.data?.id).toBe(mockOrder.id)
   })
+
+  test('should get order passenger with loyalty programme details', async () => {
+    nock(/(.*)/)
+      .get(`/air/orders/${mockOrder.id}`)
+      .reply(200, { data: mockOrder })
+
+    const response = await new Orders(new Client({ token: 'mockToken' })).get(
+      mockOrder.id
+    )
+
+    expect(response.data.passengers[0].id).toBe('pas_00009hj8USM7Ncg31cBCL')
+    expect(response.data.passengers[0].loyalty_programme_accounts).toHaveLength(
+      1
+    )
+  })
 })

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -6,6 +6,7 @@ import {
   DuffelPassengerTitle,
   DuffelPassengerType,
   FlightsConditions,
+  LoyaltyProgrammeAccount,
   OfferAvailableServiceBaggageMetadata,
   PassengerIdentityDocumentType,
   PaymentType,
@@ -159,6 +160,11 @@ export interface OrderPassenger {
    * @return "adult", "child", or "infant_without_seat"
    */
   infant_passenger_id?: string | null
+
+  /**
+   * The **Loyalty Programme Accounts** for this passenger.
+   */
+  loyalty_programme_accounts?: LoyaltyProgrammeAccount[]
 }
 
 export interface OrderPassengerIdentityDocument {

--- a/src/booking/Orders/mockOrders.ts
+++ b/src/booking/Orders/mockOrders.ts
@@ -206,6 +206,12 @@ export const mockOrder: Order = {
       gender: 'f',
       family_name: 'Earhart',
       born_on: '1987-07-24',
+      loyalty_programme_accounts: [
+        {
+          airline_iata_code: 'BA',
+          account_number: '12901014',
+        },
+      ],
     },
   ],
   owner: {


### PR DESCRIPTION
- add `family_name`, `given_name`, and `loyalty_programme_accounts` fields to OfferPassenger interface
- add `loyalty_programme_accounts` field to the OrderPassenger interface
- add unit tests