### PR TITLE
fix(booking): remove passenger validation from OrderRequests.create

### DIFF
--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -5,7 +5,6 @@ import {
   DuffelResponse,
   OfferRequest,
   PaginationMeta,
-  ValidationError,
 } from '../../types'
 
 /**
@@ -66,19 +65,6 @@ export class OfferRequests extends Resource {
     options: Partial<CreateOfferRequest & CreateOfferRequestQueryParameters>
   ): Promise<DuffelResponse<OfferRequest>> => {
     const { return_offers, ...data } = options
-
-    data.passengers &&
-      data.passengers.forEach((passenger) => {
-        if (
-          passenger.loyalty_programme_accounts &&
-          passenger.loyalty_programme_accounts.length > 0 &&
-          (!passenger.given_name || !passenger.family_name)
-        ) {
-          throw new ValidationError(
-            'loyalty programme requires family_name and given_name parameters'
-          )
-        }
-      })
 
     return this.request({
       method: 'POST',

--- a/src/types/ClientType.ts
+++ b/src/types/ClientType.ts
@@ -92,13 +92,6 @@ export class DuffelError extends Error {
   }
 }
 
-export class ValidationError extends Error {
-  constructor(message: string) {
-    super('Invalid data: ' + message)
-    this.name = 'ValidationError'
-  }
-}
-
 export interface SDKOptions {
   /**
    * If `true` it will output the path and the method called


### PR DESCRIPTION
The field is validated in the backend so we would rather surface validation errors from there directly if the field is invalid.