### PR TITLE
ci: increase commitlint header-max-length rule to 80

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = { extends: ['@commitlint/config-angular'] }
+module.exports = {
+  extends: ['@commitlint/config-angular'],
+  rules: {
+    'header-max-length': [2, 'always', 80],
+  },
+}


### PR DESCRIPTION
Some of dependabot's PR messages are longer than the [default maximum character length of `72`](https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-angular) leading to the following error during CI:
```
✖   header must not be longer than 72 characters, current length is 78 [header-max-length]
```

This PR increases the `header-max-length` commitlint rule to `80` to allow these PRs to pass the CI check.