### PR TITLE
build: add "Danvers" to eslint skipWords

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
           'departure_datetime',
           'Earheart',
           'es2021',
+          'Danvers',
         ],
         skipIfMatch: [
           'http://[^s]*',


### PR DESCRIPTION
When linting, GitHub actions marks "Danvers" as a misspelled word:
```
You have a misspelled word: Danvers on String
```
"Danvers" is used as a mock passenger's family name when creating a mock order and is the correct spelling. This PR adds "Danvers" to list of words to skip during the spellcheck to git rid of this warning.
