### PR TITLE
fix(orders): don't require `payments` when creating an order

### DIFF
--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -525,7 +525,7 @@ export interface CreateOrder {
   /**
    * The payment details to use to pay for the order
    */
-  payments: OrderPayment[]
+  payments?: OrderPayment[]
 
   /**
    * The payment action you want to take for your order. You can only use pay_later with offers that contain requires_instant_payment: false.


### PR DESCRIPTION
At the moment, the Typescript types in the library force you to provide a list of `payments` when creating an order.

`payments` is required for so-called "instant" orders.

But we should not validate this in the `CreateOrder` type because when creating a hold order (`type: "hold"`), `payments` are not required (and in fact cannot be provided!).

If you try to not pass `payments` when creating an `instant` order, the types will now allow it but you will get an error back from the API.

This bug was reported by an integrator, who is currently blocked by it, so it would be wonderful to get it merged!