### PR TITLE
fix(offer requests): tighten OfferRequests types

### DIFF
--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -1,3 +1,4 @@
+import { Client } from 'Client'
 import { Resource } from '../../Resource'
 import {
   CreateOfferRequest,
@@ -20,8 +21,8 @@ export class OfferRequests extends Resource {
    */
   path: string
 
-  constructor(args: any) {
-    super(args)
+  constructor(client: Client) {
+    super(client)
     this.path = 'air/offer_requests'
   }
 
@@ -57,12 +58,13 @@ export class OfferRequests extends Resource {
    * To search for flights, you'll need to create an `offer request`.
    * An offer request describes the passengers and where and when they want to travel (in the form of a list of `slices`).
    * It may also include additional filters (e.g. a particular cabin to travel in).
-   * @param {boolean} [return_offers] - When set to `true`, the offer request resource returned will include all the `offers` returned by the airlines.
+   * @param {Object} [options] - the parameters for making an offer requests (required: slices, passengers; optional: cabin_class, return_offers)
+   * When `return_offers` is set to `true`, the offer request resource returned will include all the `offers` returned by the airlines.
    * If set to false, the offer request resource won't include any `offers`. To retrieve the associated offers later, use the List Offers endpoint, specifying the `offer_request_id`.
    * @link https://duffel.com/docs/api/offer-requests/create-offer-request
    */
   public create = async (
-    options: Partial<CreateOfferRequest & CreateOfferRequestQueryParameters>
+    options: CreateOfferRequest & CreateOfferRequestQueryParameters
   ): Promise<DuffelResponse<OfferRequest>> => {
     const { return_offers, ...data } = options
 

--- a/src/booking/OfferRequests/OfferRequestsTypes.ts
+++ b/src/booking/OfferRequests/OfferRequestsTypes.ts
@@ -139,7 +139,7 @@ export interface CreateOfferRequest {
   /**
    * The cabin that the passengers want to travel in
    */
-  cabin_class: CabinClass
+  cabin_class?: CabinClass
 
   /**
    * The passengers who want to travel.
@@ -161,5 +161,5 @@ export interface CreateOfferRequestQueryParameters {
    * To retrieve the associated `offers` later, use the [List Offers](https://duffel.com/docs/api/offers/get-offers) endpoint, specifying the `offer_request_id`.
    * You should use this option if you want to take advantage of the pagination, sorting and filtering that the [List Offers](https://duffel.com/docs/api/offers/get-offers) endpoint provides.
    */
-  return_offers: boolean
+  return_offers?: boolean
 }


### PR DESCRIPTION
Previously, the `create` method's parameter type allows every parameter to be optional when in reality the endpoint requires `slices` and `passengers` to always be passed along. This fixes that.