### PR TITLE
fix(offer requests): ensure `offers` is inaccessible when `return_offers=false`

### DIFF
--- a/src/booking/OfferRequests/OfferRequests.spec.ts
+++ b/src/booking/OfferRequests/OfferRequests.spec.ts
@@ -106,7 +106,7 @@ describe('OfferRequests', () => {
     ).toHaveLength(1)
   })
 
-  test('should create an offer request and no offers should return when requested', async () => {
+  test('should create an offer request and return the offer request id when `return_offers` is false', async () => {
     const mockResponseWithoutOffer = { ...mockOfferRequest }
     delete mockResponseWithoutOffer.offers
     nock(/(.*)/)
@@ -120,7 +120,7 @@ describe('OfferRequests', () => {
       ...mockCreateOfferRequest,
       return_offers: false,
     })
-    expect(response.data?.offers).toBe(undefined)
+    // In this case, `offers` won't be in the response, but the offer request's id will still be returned and can be used with the List Offers endpoint to retrieve the offers.
     expect(response.data?.id).toBe(mockOfferRequest.id)
   })
 })

--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -63,9 +63,16 @@ export class OfferRequests extends Resource {
    * If set to false, the offer request resource won't include any `offers`. To retrieve the associated offers later, use the List Offers endpoint, specifying the `offer_request_id`.
    * @link https://duffel.com/docs/api/offer-requests/create-offer-request
    */
-  public create = async (
-    options: CreateOfferRequest & CreateOfferRequestQueryParameters
-  ): Promise<DuffelResponse<OfferRequest>> => {
+  public create = async <QueryParams extends CreateOfferRequestQueryParameters>(
+    options: CreateOfferRequest & QueryParams
+  ): Promise<
+    DuffelResponse<
+      // Ensure that the `offers` field can't be accessed if `return_offers` is false
+      QueryParams extends { return_offers: false }
+        ? Omit<OfferRequest, 'offers'>
+        : OfferRequest
+    >
+  > => {
     const { return_offers, ...data } = options
 
     return this.request({

--- a/src/booking/OfferRequests/OfferRequestsTypes.ts
+++ b/src/booking/OfferRequests/OfferRequestsTypes.ts
@@ -127,7 +127,7 @@ export interface OfferRequest {
   /**
    * The offers returned by the airlines
    */
-  offers?: Omit<Offer, 'available_services'>[]
+  offers: Omit<Offer, 'available_services'>[]
 
   /**
    * The passengers who want to travel. A passenger will have only a type or an age.


### PR DESCRIPTION
When an offer request is created with `return_offers` being false, the API won't return any offers. So we will reflect that in the type as well.

Demo:
![Screen Recording 2022-01-18 at 18 42 09](https://user-images.githubusercontent.com/6373626/150002920-ad46ba53-3d50-4b68-a8ef-60fce8631ac3.gif)

