### PR TITLE
fix(offers): import `Client` using a relative path

### DIFF
--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -1,4 +1,4 @@
-import { Client } from 'Client'
+import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import {
   CreateOfferRequest,

--- a/src/booking/Offers/Offers.ts
+++ b/src/booking/Offers/Offers.ts
@@ -1,4 +1,4 @@
-import { Client } from 'Client'
+import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import {
   DuffelResponse,


### PR DESCRIPTION
Previously we referred to Client without using its relative path. This causes the build to fail (example: https://github.com/duffelhq/duffel-api-javascript/issues/372). This commit fixes it by refer to `Client` using a relative path instead