### PR TITLE
fix(offers, offer requests): remove `Client` import

### DIFF
--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -1,4 +1,3 @@
-import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import {
   CreateOfferRequest,
@@ -21,7 +20,7 @@ export class OfferRequests extends Resource {
    */
   path: string
 
-  constructor(client: Client) {
+  constructor(client: any) {
     super(client)
     this.path = 'air/offer_requests'
   }

--- a/src/booking/Offers/Offers.ts
+++ b/src/booking/Offers/Offers.ts
@@ -1,4 +1,3 @@
-import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import {
   DuffelResponse,
@@ -25,7 +24,7 @@ export class Offers extends Resource {
    */
   path: string
 
-  constructor(client: Client) {
+  constructor(client: any) {
     super(client)
     this.path = 'air/offers'
   }


### PR DESCRIPTION
Importing `Client` caused `node-fetch` to be included in the package, and our rollup configuration doesn't support the way that package export things right now.