### PR TITLE
feat(order-cancellations): add support for listing Order Cancellations

### DIFF
--- a/src/booking/OrderCancellations/OrderCancellations.spec.ts
+++ b/src/booking/OrderCancellations/OrderCancellations.spec.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import { Client } from '../../Client'
-import { mockOrderCancellations } from './mockOrderCancellations'
+import { mockOrderCancellation } from './mockOrderCancellations'
 import { OrderCancellations } from './OrderCancellations'
 
 describe('OrderCancellations', () => {
@@ -11,7 +11,7 @@ describe('OrderCancellations', () => {
   test('should create a order cancellation', async () => {
     nock(/(.*)/)
       .post(`/air/order_cancellations`)
-      .reply(200, { data: mockOrderCancellations })
+      .reply(200, { data: mockOrderCancellation })
 
     const response = await new OrderCancellations(
       new Client({ token: 'mockToken' })
@@ -24,13 +24,59 @@ describe('OrderCancellations', () => {
   test('should confirm the order cancellation', async () => {
     nock(/(.*)/)
       .post(
-        `/air/order_cancellations/${mockOrderCancellations.id}/actions/confirm`
+        `/air/order_cancellations/${mockOrderCancellation.id}/actions/confirm`
       )
-      .reply(200, { data: mockOrderCancellations })
+      .reply(200, { data: mockOrderCancellation })
 
     const response = await new OrderCancellations(
       new Client({ token: 'mockToken' })
     ).confirm('ore_00009qzZWzjDipIkqpaUAj')
     expect(response.data?.order_id).toBe('ord_00009hthhsUZ8W4LxQgkjo')
+  })
+
+  test('should get a page of order cancellations', async () => {
+    nock(/(.*)/)
+      .get(`/air/order_cancellations`)
+      .query((queryObject) => {
+        expect(queryObject?.order_id).toBe('ord_123')
+        expect(queryObject?.limit).toEqual('1')
+        return true
+      })
+      .reply(200, {
+        data: [mockOrderCancellation],
+        meta: { limit: 1, before: null, after: null },
+      })
+
+    const response = await new OrderCancellations(
+      new Client({ token: 'mockToken' })
+    ).list({
+      order_id: 'ord_123',
+      limit: 1,
+    })
+    expect(response.data).toHaveLength(1)
+    expect(response.data[0].id).toBe(mockOrderCancellation.id)
+  })
+
+  test('should get all order cancellations paginated', async () => {
+    nock(/(.*)/)
+      .get(`/air/order_cancellations`)
+      .query((queryObject) => {
+        expect(queryObject?.order_id).toBe('ord_123')
+        return true
+      })
+      .reply(200, {
+        data: [mockOrderCancellation],
+        meta: { limit: 50, before: null, after: null },
+      })
+
+    const response = await new OrderCancellations(
+      new Client({ token: 'mockToken' })
+    ).listWithGenerator({
+      order_id: 'ord_123',
+    })
+
+    for await (const page of response) {
+      expect(page.data.id).toBe(mockOrderCancellation.id)
+    }
   })
 })

--- a/src/booking/OrderCancellations/OrderCancellations.ts
+++ b/src/booking/OrderCancellations/OrderCancellations.ts
@@ -3,6 +3,7 @@ import {
   CreateOrderCancellation,
   DuffelResponse,
   OrderCancellation,
+  ListOrderCancellationsParams,
 } from '../../types'
 
 export class OrderCancellations extends Resource {
@@ -23,6 +24,26 @@ export class OrderCancellations extends Resource {
    */
   public get = async (id: string): Promise<DuffelResponse<OrderCancellation>> =>
     this.request({ method: 'GET', path: `${this.path}/${id}` })
+
+  /**
+   * Retrieves a page of order cancellations. The results may be returned in any order.
+   * @param {Object.<ListOrderCancellationsParams>} params - Endpoint options (optional: limit, after, before, order_id)
+   * @link https://duffel.com/docs/api/order-cancellations/get-order-cancellations
+   */
+  public list = (
+    params?: ListOrderCancellationsParams
+  ): Promise<DuffelResponse<OrderCancellation[]>> =>
+    this.request({ method: 'GET', path: this.path, params })
+
+  /**
+   * Retrieves a generator of all order cancellations. The results may be returned in any order.
+   * @param {Object.<ListOrderCancellationsParams>} params - Endpoint options (optional: limit, after, before, order_id)
+   * @link https://duffel.com/docs/api/order-cancellations/get-order-cancellations
+   */
+  public listWithGenerator = (
+    params?: ListOrderCancellationsParams
+  ): AsyncGenerator<DuffelResponse<OrderCancellation>, void, unknown> =>
+    this.paginatedRequest({ path: this.path, params })
 
   /**
    * Create order cancellation

--- a/src/booking/OrderCancellations/OrderCancellationsTypes.ts
+++ b/src/booking/OrderCancellations/OrderCancellationsTypes.ts
@@ -1,8 +1,17 @@
+import { PaginationMeta } from '../../types'
+
 export interface CreateOrderCancellation {
   /**
    * Duffel's unique identifier for the order
    */
   order_id: string
+}
+
+export interface ListOrderCancellationsParams extends PaginationMeta {
+  /**
+   * Duffel's unique identifier for the order, returned when it was created
+   */
+  order_id?: string
 }
 
 export interface OrderCancellation {

--- a/src/booking/OrderCancellations/mockOrderCancellations.ts
+++ b/src/booking/OrderCancellations/mockOrderCancellations.ts
@@ -1,6 +1,6 @@
 import { OrderCancellation } from '../../types'
 
-export const mockOrderCancellations: OrderCancellation = {
+export const mockOrderCancellation: OrderCancellation = {
   refund_to: 'arc_bsp_cash',
   refund_currency: 'GBP',
   refund_amount: '90.80',


### PR DESCRIPTION
The Order Cancellations API [supports][1] listing order cancellations - optionally filtered by order ID.

This makes that functionality available in the library, with both manual pagination (`list`) and auto-pagination (`listWithGenerator`).

This gap in the library was reported by an integrator via a support ticket.

[1]: https://duffel.com/docs/api/order-cancellations/get-order-cancellations