### PR TITLE
feat(client): add `source` to client config (UXP-2045)

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -7,6 +7,7 @@ export interface Config {
   basePath?: string
   apiVersion?: string
   debug?: SDKOptions
+  source?: string
 }
 
 export class Client {
@@ -14,12 +15,14 @@ export class Client {
   private basePath: string
   private apiVersion: string
   private debug: SDKOptions | undefined
+  private source: string | undefined
 
-  constructor({ token, basePath, apiVersion, debug }: Config) {
+  constructor({ token, basePath, apiVersion, debug, source }: Config) {
     this.token = token
     this.basePath = basePath || 'https://api.duffel.com'
     this.apiVersion = apiVersion || 'beta'
     this.debug = debug
+    this.source = source
   }
 
   public request = async <T_Data = any>({
@@ -38,7 +41,14 @@ export class Client {
     let body
     let responseBody
     const fullPath = new URL(path, this.basePath)
-    const userAgent = `Duffel/${this.apiVersion} duffel_api_javascript/${process.env.npm_package_version}`
+    const userAgent = [
+      `Duffel/${this.apiVersion}`,
+      `duffel_api_javascript/${process.env.npm_package_version}`,
+      this.source ? `source/${this.source}` : '',
+    ]
+      .join(' ')
+      .trim()
+
     const headers = {
       'User-Agent': userAgent,
       Accept: 'application/json',


### PR DESCRIPTION
This is to allow us to have more visibility on where the API is being made from, so we can prioritize our further investment. The source will become part of the userAgent and would allow us to perform analytics on the usage. 

Apps created via `create-duffel-app` will have source populated to include the information of the type of templates being use.

