### PR TITLE
fix(order): fix the expected type for order creation passengers

### DIFF
--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -189,11 +189,11 @@ export interface OrderPassengerIdentityDocument {
   expires_on: string
 }
 
-export interface CreateOrderPassenger extends OrderPassenger {
+export interface CreateOrderPassenger extends Omit<OrderPassenger, 'type'> {
   /**
    * The passenger's identity documents. You may only provide one identity document per passenger. The identity document's type must be included in the offer's allowed_passenger_identity_document_types. If the offer's passenger_identity_documents_required is set to true, then an identity document must be provided.
    */
-  identity_documents: OrderPassengerIdentityDocument[]
+  identity_documents?: OrderPassengerIdentityDocument[]
 
   /**
    * The passenger's email address
@@ -206,6 +206,14 @@ export interface CreateOrderPassenger extends OrderPassenger {
    * @example "+442080160509"
    */
   phone_number: string
+
+  /**
+   * @deprecated This type is here just for the backward-compatibility until the field is officially removed from the API
+   *
+   * The type of the passenger
+   * @example "adult", "child", or "infant_without_seat"
+   */
+  type?: DuffelPassengerType
 }
 
 export interface OrderSliceSegment {

--- a/src/booking/Orders/mockOrders.ts
+++ b/src/booking/Orders/mockOrders.ts
@@ -18,7 +18,6 @@ export const mockCreateOrderRequest: CreateOrder = {
   ],
   passengers: [
     {
-      type: 'adult',
       title: 'mrs',
       phone_number: '+442080160509',
       infant_passenger_id: 'pas_00009hj8USM8Ncg32aTGHL',


### PR DESCRIPTION
Update the types for order creation passengers to match the schema https://duffel.com/docs/api/orders/create-order
- passenger's `type` is deprecated 
<img width="553" alt="image" src="https://user-images.githubusercontent.com/6373626/160151553-415735e8-50f8-43e6-88d2-4d98dfe8a941.png">

- `identity_documents` is optional 
<img width="581" alt="image" src="https://user-images.githubusercontent.com/6373626/160151633-04e8cfb7-d858-4ab8-abd6-1329ded47736.png">
