### PR TITLE
fix(client): fix DuffelError exporting

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,6 +1,11 @@
 import fetch from 'node-fetch'
 import { URL, URLSearchParams } from 'url'
-import { DuffelError, DuffelResponse, SDKOptions } from './types'
+import {
+  DuffelResponse,
+  SDKOptions,
+  ApiResponseMeta,
+  ApiResponseError,
+} from './types'
 
 export interface Config {
   token: string
@@ -8,6 +13,23 @@ export interface Config {
   apiVersion?: string
   debug?: SDKOptions
   source?: string
+}
+
+export class DuffelError extends Error {
+  public meta: ApiResponseMeta
+  public errors: ApiResponseError[]
+
+  constructor({
+    meta,
+    errors,
+  }: {
+    meta: ApiResponseMeta
+    errors: ApiResponseError[]
+  }) {
+    super()
+    this.meta = meta
+    this.errors = errors
+  }
 }
 
 export class Client {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,8 @@ import {
   Payments,
   SeatMaps,
 } from './booking'
-import { Client, Config } from './Client'
+import { Client, Config, DuffelError as _DuffelError } from './Client'
 import { Aircraft, Airlines, Airports } from './supportingResources'
-import { DuffelError as _DuffelError } from './types/ClientType'
 export interface DuffelAPIClient {
   aircraft: Aircraft
   airlines: Airlines

--- a/src/types/ClientType.ts
+++ b/src/types/ClientType.ts
@@ -75,23 +75,6 @@ export interface DuffelResponse<T_Data> {
   meta?: PaginationMeta
 }
 
-export class DuffelError extends Error {
-  public meta: ApiResponseMeta
-  public errors: ApiResponseError[]
-
-  constructor({
-    meta,
-    errors,
-  }: {
-    meta: ApiResponseMeta
-    errors: ApiResponseError[]
-  }) {
-    super()
-    this.meta = meta
-    this.errors = errors
-  }
-}
-
 export interface SDKOptions {
   /**
    * If `true` it will output the path and the method called


### PR DESCRIPTION
Previously DuffelError was exported as both a type and a value. This led to a naming conflict and caused `DuffelError` to not be importable through `@duffel/api`.

To fix that, we will move this class out of `ClientType`, so that it can be imported as both a value and a type.