### PR TITLE
Force `minimist` to resolve to v1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
       "prettier --write"
     ]
   },
+  "resolutions": {
+    "minimist": "1.2.6"
+  },
   "dependencies": {
     "@types/node": "^17.0.21",
     "@types/node-fetch": "^2.6.1",


### PR DESCRIPTION
The `commitzen` package has not been [updated since 7 May 2021](https://github.com/commitizen/cz-cli/tree/v4.2.4) which means that numerous security patches haven't been released as new package versions.

This change forces a version on `minimist` which is not vulnerable to CVE-2021-44906.

See this following security advisory for more information:
https://github.com/advisories/GHSA-xvch-5gv4-984h