### PR TITLE
feat: add Partial Offer Requests api

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -81,10 +81,20 @@ export class Client {
     }
 
     if (params) {
-      const sortedParams = Object.entries(params)
+      const params_with_array_expanded = new URLSearchParams()
+      Object.entries(params)
         .sort()
         .filter((option) => option[0] !== null)
-      fullPath.search = new URLSearchParams(sortedParams).toString()
+        .forEach(([key, value]) => {
+          if (Array.isArray(value)) {
+            value.forEach((value) =>
+              params_with_array_expanded.append(key, value.toString())
+            )
+          } else {
+            params_with_array_expanded.append(key, value.toString())
+          }
+        })
+      fullPath.search = params_with_array_expanded.toString()
     }
 
     // We need to format body to be sent as { "data": data }

--- a/src/booking/Offers/OfferTypes.ts
+++ b/src/booking/Offers/OfferTypes.ts
@@ -127,6 +127,13 @@ export interface Offer {
    * The ISO 8601 datetime at which the offer was last updated
    */
   updated_at: string
+
+  /**
+   * Whether this is a partial or full offer.
+   * A partial offer can't be booked directly, but it can be combined with other partial offers to form a full offer.
+   * Partial offers are only ever returned through the multi-step search flow.
+   */
+  partial: boolean
 }
 
 export interface OfferAvailableServiceBaggageMetadata {

--- a/src/booking/Offers/mockPartialOffer.ts
+++ b/src/booking/Offers/mockPartialOffer.ts
@@ -1,6 +1,6 @@
 import { Offer } from '../../types'
 
-export const mockOffer: Offer = {
+export const mockPartialOffer: Offer = {
   updated_at: '2020-01-17T10:12:14.545Z',
   total_emissions_kg: '460',
   total_currency: 'GBP',
@@ -140,7 +140,7 @@ export const mockOffer: Offer = {
     price_guarantee_expires_at: '2020-01-17T10:42:14.545Z',
     payment_required_by: '2020-01-17T10:42:14.545Z',
   },
-  partial: false,
+  partial: true,
   passengers: [
     {
       type: 'adult',

--- a/src/booking/PartialOfferRequests/PartialOfferRequestTypes.ts
+++ b/src/booking/PartialOfferRequests/PartialOfferRequestTypes.ts
@@ -1,0 +1,6 @@
+export interface SelectedPartialOffersParams {
+  /**
+   * Whether to filter orders that are awaiting payment or not. If not specified, all orders regardless of their payment state will be returned.
+   */
+  'selected_partial_offer[]'?: string[]
+}

--- a/src/booking/PartialOfferRequests/PartialOfferRequests.spec.ts
+++ b/src/booking/PartialOfferRequests/PartialOfferRequests.spec.ts
@@ -1,0 +1,67 @@
+import nock from 'nock'
+import { Client } from '../../Client'
+import {
+  mockCreatePartialOfferRequest,
+  mockPartialOfferRequest,
+} from './mockPartialOfferRequest'
+import { PartialOfferRequests } from './PartialOfferRequests'
+
+describe('PartialOfferRequests', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  test('should get a partial offer request with selected offer', async () => {
+    nock(/(.*)/)
+      .get(`/air/partial_offer_requests/${mockPartialOfferRequest.id}`)
+      .query((queryObject) => {
+        expect(queryObject['selected_partial_offer[]']).toEqual([
+          'partial_offer_1',
+          'partial_offer_2',
+        ])
+        return true
+      })
+      .reply(200, { data: mockPartialOfferRequest })
+
+    const response = await new PartialOfferRequests(
+      new Client({ token: 'mockToken' })
+    ).get(mockPartialOfferRequest.id, {
+      'selected_partial_offer[]': ['partial_offer_1', 'partial_offer_2'],
+    })
+    expect(response.data?.id).toBe(mockPartialOfferRequest.id)
+    expect(response.data?.offers.length).toBeGreaterThan(0)
+  })
+
+  test('should create an offer request and return offers', async () => {
+    nock(/(.*)/)
+      .post(`/air/partial_offer_requests/`)
+      .reply(200, { data: mockPartialOfferRequest })
+
+    const response = await new PartialOfferRequests(
+      new Client({ token: 'mockToken' })
+    ).create(mockCreatePartialOfferRequest)
+    expect(response.data?.id).toBe(mockPartialOfferRequest.id)
+    expect(response.data?.offers.length).toBeGreaterThan(0)
+  })
+
+  test('should get a fares request with selected offers', async () => {
+    nock(/(.*)/)
+      .get(`/air/partial_offer_requests/${mockPartialOfferRequest.id}/fares`)
+      .query((queryObject) => {
+        expect(queryObject['selected_partial_offer[]']).toEqual([
+          'partial_offer_1',
+          'partial_offer_2',
+        ])
+        return true
+      })
+      .reply(200, { data: mockPartialOfferRequest })
+
+    const response = await new PartialOfferRequests(
+      new Client({ token: 'mockToken' })
+    ).getFaresById(mockPartialOfferRequest.id, {
+      'selected_partial_offer[]': ['partial_offer_1', 'partial_offer_2'],
+    })
+    expect(response.data?.id).toBe(mockPartialOfferRequest.id)
+    expect(response.data?.offers.length).toBeGreaterThan(0)
+  })
+})

--- a/src/booking/PartialOfferRequests/PartialOfferRequests.ts
+++ b/src/booking/PartialOfferRequests/PartialOfferRequests.ts
@@ -1,0 +1,74 @@
+import { Client } from 'Client'
+import { Resource } from '../../Resource'
+import { CreateOfferRequest, DuffelResponse, OfferRequest } from '../../types'
+import { SelectedPartialOffersParams } from './PartialOfferRequestTypes'
+
+/**
+ * To search for and select flights separately for each slice of the journey, you'll need to create a partial offer request.
+ *
+ * A partial offer request describes the passengers and where and when they want to travel (in the form of a list of slices).
+ * @class
+ * @link https://duffel.com/docs/api/partial-offer-requests
+ */
+export class PartialOfferRequests extends Resource {
+  /**
+   * Endpoint path
+   */
+  path: string
+
+  constructor(client: Client) {
+    super(client)
+    this.path = 'air/partial_offer_requests'
+  }
+
+  /**
+   * Retrieves a partial offers request by its ID, only including partial offers for the current slice of multi-step search flow.
+   * @param {string} id - Duffel's unique identifier for the partial offer request
+   * @param {Object} [options] - Selected partial offers
+   * @link https:/duffel.com/docs/api/partial-offer-requests/get-partial-offer-request-by-id
+   */
+  public get = async (
+    id: string,
+    options?: SelectedPartialOffersParams
+  ): Promise<DuffelResponse<OfferRequest>> => {
+    return this.request({
+      method: 'GET',
+      path: `${this.path}/${id}`,
+      params: options,
+    })
+  }
+
+  /**
+   * To search for and select flights separately for each slice of the journey, you'll need to create a partial offer request.
+   * A partial offer request describes the passengers and where and when they want to travel (in the form of a list of slices).
+   * It may also include additional filters (e.g. a particular cabin to travel in).
+   * @param {Object} [options] - the parameters for making a partial offer requests (required: slices, passengers; optional: cabin_class)
+   * @link https://duffel.com/docs/api/partial-offer-requests/create-partial-offer-request
+   */
+  public create = async <QueryParams>(
+    options: CreateOfferRequest & QueryParams
+  ): Promise<DuffelResponse<OfferRequest>> => {
+    return this.request({
+      method: 'POST',
+      path: `${this.path}/`,
+      data: options,
+    })
+  }
+
+  /**
+   * Retrieves an offer request with offers for fares matching selected partial offers..
+   * @param {string} id - Duffel's unique identifier for the partial offer request
+   * @param {Object} [options] - Selected partial offers
+   * @link https:/duffel.com/docs/api/partial-offer-requests/get-partial-offer-request-fares-by-id
+   */
+  public getFaresById = async (
+    id: string,
+    options?: SelectedPartialOffersParams
+  ): Promise<DuffelResponse<OfferRequest>> => {
+    return this.request({
+      method: 'GET',
+      path: `${this.path}/${id}/fares`,
+      params: options,
+    })
+  }
+}

--- a/src/booking/PartialOfferRequests/index.ts
+++ b/src/booking/PartialOfferRequests/index.ts
@@ -1,0 +1,1 @@
+export * from './PartialOfferRequests'

--- a/src/booking/PartialOfferRequests/mockPartialOfferRequest.ts
+++ b/src/booking/PartialOfferRequests/mockPartialOfferRequest.ts
@@ -1,0 +1,119 @@
+import { mockPartialOffer } from '../Offers/mockPartialOffer'
+import { CreateOfferRequest, OfferRequest } from '../../types'
+
+export const mockCreatePartialOfferRequest: CreateOfferRequest = {
+  slices: [
+    {
+      origin: 'LHR',
+      destination: 'JFK',
+      departure_date: '2020-04-24',
+    },
+  ],
+  passengers: [
+    {
+      type: 'adult',
+    },
+    {
+      age: 14,
+    },
+  ],
+  cabin_class: 'economy',
+}
+
+export const mockPartialOfferRequest: OfferRequest = {
+  slices: [
+    {
+      origin_type: 'airport',
+      origin: {
+        type: 'airport',
+        time_zone: 'Europe/London',
+        name: 'Heathrow',
+        longitude: -141.951519,
+        latitude: 64.068865,
+        id: 'arp_lhr_gb',
+        icao_code: 'EGLL',
+        iata_country_code: 'GB',
+        iata_code: 'LHR',
+        iata_city_code: 'LON',
+        city_name: 'London',
+        city: {
+          name: 'London',
+          id: 'cit_lon_gb',
+          iata_country_code: 'GB',
+          iata_code: 'LON',
+        },
+        airports: [
+          {
+            time_zone: 'Europe/London',
+            name: 'Heathrow',
+            longitude: -141.951519,
+            latitude: 64.068865,
+            id: 'arp_lhr_gb',
+            icao_code: 'EGLL',
+            iata_country_code: 'GB',
+            iata_code: 'LHR',
+            city_name: 'London',
+            city: {
+              name: 'London',
+              id: 'cit_lon_gb',
+              iata_country_code: 'GB',
+              iata_code: 'LON',
+            },
+          },
+        ],
+      },
+      destination_type: 'airport',
+      destination: {
+        type: 'airport',
+        time_zone: 'Europe/London',
+        name: 'Heathrow',
+        longitude: -141.951519,
+        latitude: 64.068865,
+        id: 'arp_lhr_gb',
+        icao_code: 'EGLL',
+        iata_country_code: 'GB',
+        iata_code: 'LHR',
+        iata_city_code: 'LON',
+        city_name: 'London',
+        city: {
+          name: 'London',
+          id: 'cit_lon_gb',
+          iata_country_code: 'GB',
+          iata_code: 'LON',
+        },
+        airports: [
+          {
+            time_zone: 'Europe/London',
+            name: 'Heathrow',
+            longitude: -141.951519,
+            latitude: 64.068865,
+            id: 'arp_lhr_gb',
+            icao_code: 'EGLL',
+            iata_country_code: 'GB',
+            iata_code: 'LHR',
+            city_name: 'London',
+            city: {
+              name: 'London',
+              id: 'cit_lon_gb',
+              iata_country_code: 'GB',
+              iata_code: 'LON',
+            },
+          },
+        ],
+      },
+      departure_date: '2020-04-24',
+    },
+  ],
+  passengers: [
+    {
+      type: 'adult',
+      id: 'pas_00009hj8USM7Ncg31cBCL',
+      age: 14,
+    },
+  ],
+  offers: [mockPartialOffer],
+  live_mode: false,
+  id: 'orq_00009hjdomFOCJyxHG7k7k',
+  created_at: '2020-02-12T15:21:01.927Z',
+  cabin_class: 'economy',
+}


### PR DESCRIPTION
Adds support for [partial offer requests](https://duffel.com/docs/api/partial-offer-requests) which in used multi-step search
flow.

Required changing the client to handle array query string parameters by
repeating array key.
