### PR TITLE
[UXP-2487] Uses on `pull_request_target` hook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: 'CI: Pull request'
 
-on: push
+on: [push, pull_request_target]
 
 jobs:
   Linting:


### PR DESCRIPTION
__What__

When developers are raising PRs from forked branches our Github checks are not running. Seif had this issue before and Tim just had this issue. This updates our main action to Github Actions from `push` to `pull_request_target` to allow that.