### PR TITLE
build(gh-actions): prevent ci running on pull_request_target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: 'CI: Pull request'
 
-on: [push, pull_request_target]
+on: [push]
 
 jobs:
   Linting:


### PR DESCRIPTION
See [this Slack thread](https://duffel.slack.com/archives/C033WEHE4CR/p1655136888645379?thread_ts=1655113215.075649&cid=C033WEHE4CR) for more context