### PR TITLE
build: make renovate use build for commit messages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,8 @@
 {
-  "extends": ["config:base", ":semanticCommitType(build)"],
+  "extends": [
+    "config:base",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(build)"
+  ],
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
This should prevent the issues we're seeing on Renovate's other PRs where it's using `chore` which isn't allowed under our commit conventions.