### PR TITLE
[UXP-2482] Make Renovate config more opinionated

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,15 @@
   "extends": [
     "config:base",
     ":semanticCommits",
-    ":semanticCommitTypeAll(build)"
+    ":semanticCommitTypeAll(build)",
+    "schedule:earlyMondays",
+    ":combinePatchMinorReleases"
   ],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["eslint", "prettier"],
+      "automerge": true
+    }
+  ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,9 @@ See `package.json` for other scripts that can be run (e.g. linters).
 ## Committing code
 
 We use [commitlint](https://github.com/conventional-changelog/commitlint) to lint our commit messages. If your commit message doesn't fit this format, it'll be rejected by a pre-commit hook.
+
+## Renovate
+
+We use [Renovate](https://www.mend.io/free-developer-tools/renovate/) to manage dependencies. The config file is at `.github/renovate.json`.
+
+We seek to maintain a balance between thoroughly checking each dependency and spending too much time maintaining dependencies, so our settings are designed to **safely** reduce noise reduction from dependency updates, like scheduling updates outside of working hours, combining some PRs, and automatically merging dependencies where we can be 100% confident in our CI's ability to catch problems. For example, we automerge linter PRs because it's virtually impossible for them to break something in production as they only check code, they don't affect any functionality.


### PR DESCRIPTION
This is the final Renovate PR from me as part of this ticket. Now that we've had Renovate running all week without issue, it adds some configuration options aimed at reducing the workload from managing dependency updates.

It does the following:

* Only runs Renovate weekly, prior to work on Monday. This will mean we only have to worry about dependency updates once per week.
* Combines patch and minor updates into a single PR, to make it easier to manage. The PR may be slightly more work to review, but the benefits should outweigh the downsides as the overhead from merging one larger PR is much smaller than merging several small PRs.
* Turns on automerge for eslint and Prettier. I have deliberately been very conservative with which dependencies can automerge, as it's potentially dangerous. eslint and Prettier are probably the safest dependencies we have, as it's virtually impossible for them to break something. If this works well for us we may wish to slowly expand the dependencies we automerge (e.g. TypeScript and @types repos could be good candidates).

Happy to discuss any of the changes – this config should be a living thing owned by all of us.

One cool thing is that you can publish your own presets (the things in the `extends` array), so if we are able to use Renovate in more repos in the future, we could have a single config cross all our repos.