### PR TITLE
feat(headers): shows http headers in client response

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -18,17 +18,21 @@ export interface Config {
 export class DuffelError extends Error {
   public meta: ApiResponseMeta
   public errors: ApiResponseError[]
+  public headers: Record<string, string>
 
   constructor({
     meta,
     errors,
+    headers,
   }: {
     meta: ApiResponseMeta
     errors: ApiResponseError[]
+    headers: Record<string, string>
   }) {
     super()
     this.meta = meta
     this.errors = errors
+    this.headers = headers
   }
 }
 
@@ -129,10 +133,10 @@ export class Client {
     }
 
     if (!response.ok || ('errors' in responseBody && responseBody.errors)) {
-      throw new DuffelError(responseBody)
+      throw new DuffelError({ ...responseBody, headers: response.headers })
     }
 
-    return responseBody
+    return { ...responseBody, headers: response.headers }
   }
 
   async *paginatedRequest<T_Data = any>({

--- a/src/types/ClientType.ts
+++ b/src/types/ClientType.ts
@@ -73,6 +73,11 @@ export interface DuffelResponse<T_Data> {
    * Optional metadata for the request
    */
   meta?: PaginationMeta
+
+  /**
+   * The headers from the http response
+   */
+  headers?: Record<string, string>
 }
 
 export interface SDKOptions {


### PR DESCRIPTION
__what__

Before, we'd only return the http body, this meant users don't have visibility on rate limiting and request id headers. This PR includes the headers object on every success and error response. 