### PR TITLE
fix(headers): update response interface to use correct headers type

### DIFF
--- a/src/types/ClientType.ts
+++ b/src/types/ClientType.ts
@@ -1,3 +1,5 @@
+import { Headers } from 'node-fetch'
+
 /**
  * Our list APIs will only return a limited number of results at a time.
  * By default, we'll return 50 results per page, but you can set this to any number between 1 and 200.
@@ -77,7 +79,7 @@ export interface DuffelResponse<T_Data> {
   /**
    * The headers from the http response
    */
-  headers?: Record<string, string>
+  headers?: Headers
 }
 
 export interface SDKOptions {


### PR DESCRIPTION
## 🔍 Overview

This PR updates the `headers` type in the `DuffelResponse` interface to match what is returned from `fetch`.

## ❓Why was this done?

The current headers type (`Record<string, string>`) was causing issues when trying to apply headers to a server response on our internal dashboard tool.
