### PR TITLE
feat(booking): add ability to retrieve and add services for an order

### DIFF
--- a/src/booking/Orders/Orders.spec.ts
+++ b/src/booking/Orders/Orders.spec.ts
@@ -1,9 +1,11 @@
 import nock from 'nock'
 import { Client } from '../../Client'
 import {
+  mockAddServicesRequest,
   mockCreateOrderRequest,
   mockOnHoldOrders,
   mockOrder,
+  mockServices,
 } from './mockOrders'
 import { Orders } from './Orders'
 
@@ -167,5 +169,29 @@ describe('Orders', () => {
     expect(response.data.passengers[0].loyalty_programme_accounts).toHaveLength(
       1
     )
+  })
+
+  test('should get available services for an order', async () => {
+    nock(/(.*)/)
+      .get(`/air/orders/${mockOrder.id}/available_services`)
+      .reply(200, { data: mockServices })
+
+    const response = await new Orders(
+      new Client({ token: 'mockToken' })
+    ).getAvailableServices(mockOrder.id)
+
+    expect(response.data[0].id).toBe(mockServices[0].id)
+  })
+
+  test('should add services to an order', async () => {
+    nock(/(.*)/)
+      .post(`/air/orders/${mockOrder.id}/services`)
+      .reply(200, { data: { ...mockOrder, services: mockServices } })
+
+    const response = await new Orders(
+      new Client({ token: 'mockToken' })
+    ).addServices(mockOrder.id, mockAddServicesRequest)
+
+    expect(response.data.services[0].id).toBe(mockServices[0].id)
   })
 })

--- a/src/booking/Orders/Orders.ts
+++ b/src/booking/Orders/Orders.ts
@@ -1,9 +1,11 @@
 import { Resource } from '../../Resource'
 import {
+  AddServices,
   CreateOrder,
   DuffelResponse,
   ListParamsOrders,
   Order,
+  OrderAvailableService,
   PaginationMeta,
   UpdateSingleOrder,
 } from '../../types'
@@ -74,4 +76,32 @@ export class Orders extends Resource {
       data: { options },
     })
   }
+
+  /**
+   * Retrieves the available services for an order by its ID
+   * @param {string} id - Duffel's unique identifier for the order
+   */
+  public getAvailableServices = async (
+    id: string
+  ): Promise<DuffelResponse<OrderAvailableService[]>> =>
+    this.request({
+      method: 'GET',
+      path: `${this.path}/${id}/available_services`,
+    })
+
+  /**
+   * Adds services for an order by its ID
+   * @param {string} id - Duffel's unique identifier for the order
+   * @param {Object.AddServices} options
+   * @link https://duffel.com/docs/api/orders/create-order-services
+   */
+  public addServices = async (
+    id: string,
+    options: AddServices
+  ): Promise<DuffelResponse<Order>> =>
+    this.request({
+      method: 'POST',
+      path: `${this.path}/${id}/services`,
+      data: { options },
+    })
 }

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -7,6 +7,7 @@ import {
   DuffelPassengerType,
   FlightsConditions,
   LoyaltyProgrammeAccount,
+  OfferAvailableService,
   OfferAvailableServiceBaggageMetadata,
   PassengerIdentityDocumentType,
   PaymentType,
@@ -561,3 +562,10 @@ export interface ListParamsOrders {
 export interface UpdateSingleOrder {
   metadata: Order['metadata']
 }
+
+export interface AddServices {
+  payments: OrderPayment[]
+  add_services: Pick<OrderService, 'id' | 'quantity'>[]
+}
+
+export type OrderAvailableService = OfferAvailableService

--- a/src/booking/Orders/mockOrders.ts
+++ b/src/booking/Orders/mockOrders.ts
@@ -1,4 +1,9 @@
-import { CreateOrder, Order } from '../../types'
+import {
+  AddServices,
+  CreateOrder,
+  Order,
+  OrderAvailableService,
+} from '../../types'
 
 export const mockCreateOrderRequest: CreateOrder = {
   type: 'instant',
@@ -568,3 +573,26 @@ export const mockOnHoldOrders: Order[] = [
     base_amount: '93.00',
   },
 ]
+
+export const mockServices: OrderAvailableService[] = [
+  {
+    type: 'baggage',
+    total_currency: 'GBP',
+    total_amount: '15.00',
+    segment_ids: ['seg_00009hj8USM7Ncg31cB456'],
+    passenger_ids: ['pas_00009hj8USM7Ncg31cBCLL'],
+    maximum_quantity: 1,
+    id: 'aso_00009UhD4ongolulWd9123',
+  },
+]
+
+export const mockAddServicesRequest: AddServices = {
+  payments: [
+    {
+      type: 'balance',
+      currency: 'GBP',
+      amount: '30.20',
+    },
+  ],
+  add_services: [{ id: 'aso_00009UhD4ongolulWd9123', quantity: 1 }],
+}


### PR DESCRIPTION
This PR adds functionality for getting available services for an order, and booking services for an order.

Docs:
- https://duffel.com/docs/api/orders/create-order-services
- https://duffel.com/docs/guides/adding-post-booking-bags