### PR TITLE
[No Jira] Address a couple of issues

### DIFF
--- a/src/booking/OfferRequests/OfferRequestsTypes.ts
+++ b/src/booking/OfferRequests/OfferRequestsTypes.ts
@@ -158,6 +158,12 @@ export interface CreateOfferRequest {
    * One-way journeys can be expressed using one slice, whereas return trips will need two.
    */
   slices: Omit<OfferRequestSlice, 'origin_type' | 'destination_type'>[]
+
+  /**
+   * The maximum number of connections within any slice of the offer.
+   * For example 0 means a direct flight which will have a single segment within each slice and 1 means a maximum of two segments within each slice of the offer.
+   */
+  max_connections?: 0 | 1 | 2
 }
 
 export interface CreateOfferRequestQueryParameters {

--- a/src/booking/OfferRequests/mockOfferRequest.ts
+++ b/src/booking/OfferRequests/mockOfferRequest.ts
@@ -18,6 +18,7 @@ export const mockCreateOfferRequest: CreateOfferRequest = {
     },
   ],
   cabin_class: 'economy',
+  max_connections: 1,
 }
 
 export const mockOfferRequest: OfferRequest = {

--- a/src/booking/Offers/OfferTypes.ts
+++ b/src/booking/Offers/OfferTypes.ts
@@ -9,6 +9,7 @@ import {
   Airline,
   Airport,
   PaginationMeta,
+  DuffelPassengerType,
 } from '../../types'
 
 /**
@@ -250,7 +251,7 @@ export interface OfferPassenger {
   /**
    * The type of the passenger.
    */
-  type?: 'adult'
+  type?: DuffelPassengerType
 
   /**
    * The passenger's family name. Only `space`, `-`, `'`, and letters from the `ASCII`, `Latin-1 Supplement` and `Latin


### PR DESCRIPTION
Two changes in this PR to address two issues raised by a user:

1. Added `max_connections` to `OfferRequestType`. I took the description from our docs site: https://duffel.com/docs/api/v1/offer-requests/create-offer-request#offer-requests-create-an-offer-request-body-parameters-max-connections. I also added it to our mock to prove it works correctly. (Addresses #656)
2. Use `DuffelPassengerType` instead of `'adult'` on `OfferTypes`. (Addresses #658)