### PR TITLE
fix(ci): uses node 18 for semantic-release to work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
__what__

> semantic-release is written using the latest [ECMAScript 2017](https://www.ecma-international.org/publications/standards/Ecma-262.htm) features, without transpilation which requires Node version 18.0.0 or higher. ([source](https://github.com/semantic-release/semantic-release/blob/HEAD/docs/support/node-version.md#node-version-requirement))

So we need to update the version we use on CI to match. This PR fixes [this issue](https://duffel.slack.com/archives/C013XQ3T2J1/p1673519961713899).