### PR TITLE
feat(links): add Links module

### DIFF
--- a/src/Links/Links.spec.ts
+++ b/src/Links/Links.spec.ts
@@ -1,0 +1,24 @@
+import nock from 'nock'
+import { Duffel } from '../index'
+
+const duffel = new Duffel({ token: 'mockToken' })
+describe('Links', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should post to /links/generate_link when `generateLink` is called', async () => {
+    const MOCK_URL = 'https://links.duffel.com/?token=abcdef'
+    nock(/(.*)/)
+      .post('/links/generate_link')
+      .reply(200, { data: { url: MOCK_URL } })
+
+    const response = await duffel.links.generateLink({
+      reference: 'test',
+      success_url: 'https://example.com',
+      failure_url: 'https://example.com',
+      abandonment_url: 'https://example.com',
+    })
+    expect(response.data.url).toBe(MOCK_URL)
+  })
+})

--- a/src/Links/Links.ts
+++ b/src/Links/Links.ts
@@ -1,0 +1,73 @@
+import { Client } from 'Client'
+import { Resource } from '../Resource'
+import { DuffelResponse } from '../types'
+
+interface GenerateLinkParameters {
+  /**
+   * A tracking reference for the booking that may be created within this Duffel Links session
+   */
+  reference: string
+  /**
+   * A url to return to when a flight is booked via Duffel Links
+   */
+  success_url: string
+  /**
+   * A url to return to when there is an error within Duffel Links
+   */
+  failure_url: string
+  /**
+   * A url to return to when the user exits Duffel Links before booking
+   */
+  abandonment_url: string
+  /**
+   * A primary color to show within Duffel Links
+   */
+  primary_color?: string
+  /**
+   * A url of the logo to show within Duffel Links
+   */
+  logo_url?: string
+  /**
+   * A markup amount to be added to the flights shown within Duffel Links
+   */
+  markup_amount?: number
+  /**
+   * A markup amount to be added to the flights shown within Duffel Links
+   */
+  markup_currency?: string
+  /**
+   * A markup percentage to be added to the flights shown within Duffel Links
+   */
+  markup_rate?: number
+  /**
+   * A text to be shown on the checkout page within Duffel Links
+   */
+  checkout_display_text?: string
+}
+
+interface GeneratedLink {
+  /**
+   * The Duffel Links url that contains the specified configuration
+   */
+  url: string
+}
+
+export class Links extends Resource {
+  /**
+   * Endpoint path
+   */
+  path: string
+
+  constructor(client: Client) {
+    super(client)
+    this.path = 'links'
+  }
+
+  /**
+   * Generate a Duffel Link per the configuration
+   */
+  public generateLink = async (
+    data: GenerateLinkParameters
+  ): Promise<DuffelResponse<GeneratedLink>> =>
+    this.request({ method: 'POST', path: `${this.path}/generate_link`, data })
+}

--- a/src/Links/index.ts
+++ b/src/Links/index.ts
@@ -1,0 +1,1 @@
+export * from './Links'

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { Client, Config, DuffelError as _DuffelError } from './Client'
 import { Aircraft, Airlines, Airports } from './supportingResources'
 import { Suggestions } from './Places/Suggestions'
 import { Refunds } from './DuffelPayments/Refunds'
+import { Links } from './Links'
 export interface DuffelAPIClient {
   aircraft: Aircraft
   airlines: Airlines
@@ -35,6 +36,7 @@ export class Duffel {
   public aircraft: Aircraft
   public airlines: Airlines
   public airports: Airports
+  public links: Links
   public offerRequests: OfferRequests
   public offers: Offers
   public orders: Orders
@@ -55,6 +57,7 @@ export class Duffel {
     this.aircraft = new Aircraft(this.client)
     this.airlines = new Airlines(this.client)
     this.airports = new Airports(this.client)
+    this.links = new Links(this.client)
     this.offerRequests = new OfferRequests(this.client)
     this.offers = new Offers(this.client)
     this.orders = new Orders(this.client)


### PR DESCRIPTION
Also add a `duffel.links.generateLink` method which calls `/links/generate_link` endpoint underneath.