### PR TITLE
fix(aic): fix wrong type expected in AIC update method

### DIFF
--- a/src/booking/AirlineInitiatedChanges/AirlineInitiatedChanges.spec.ts
+++ b/src/booking/AirlineInitiatedChanges/AirlineInitiatedChanges.spec.ts
@@ -20,7 +20,7 @@ describe('AirlineInitiatedChanges', () => {
 
     const response = await new AirlineInitiatedChanges(mockClient).update(
       mockAirlineInitiatedChange.id,
-      'accept'
+      'accepted'
     )
     expect(response.data.id).toEqual(mockAirlineInitiatedChange.id)
     expect(response.data.action_taken).toBe('accepted')

--- a/src/booking/AirlineInitiatedChanges/AirlineInitiatedChanges.ts
+++ b/src/booking/AirlineInitiatedChanges/AirlineInitiatedChanges.ts
@@ -1,11 +1,10 @@
 import { Client } from '../../Client'
 import { Resource } from '../../Resource'
+import { DuffelResponse, Order } from '../../types'
 import {
-  AirlineInitiatedChangeAvailableAction,
-  DuffelResponse,
-  Order,
-} from '../../types'
-import { AirlineInitiatedChange } from './AirlineInitiatedChangesTypes'
+  AirlineInitiatedChange,
+  AirlineInitiatedChangeActionTaken,
+} from './AirlineInitiatedChangesTypes'
 
 /**
  * Sometimes there can be changes to your order initiated by the airline, for
@@ -52,7 +51,7 @@ export class AirlineInitiatedChanges extends Resource {
    */
   public update = async (
     id: AirlineInitiatedChange['id'],
-    action_taken: AirlineInitiatedChangeAvailableAction
+    action_taken: AirlineInitiatedChangeActionTaken
   ): Promise<DuffelResponse<AirlineInitiatedChange>> =>
     this.request({
       method: 'PATCH',


### PR DESCRIPTION
We previously used the wrong type for the parameter. This fixes it.