### PR TITLE
feat(booking): add tax_id to PassengerIdentityDocumentType

### DIFF
--- a/src/booking/Offers/OfferTypes.ts
+++ b/src/booking/Offers/OfferTypes.ts
@@ -19,7 +19,7 @@ import {
 export interface Offer {
   /**
    * The types of identity documents that may be provided for the passengers when creating an order based on this offer.
-   * Currently, the only supported type is `passport`. If this is `[]`, then you must not provide identity documents.
+   * If this is `[]`, then you must not provide identity documents.
    */
   allowed_passenger_identity_document_types: PassengerIdentityDocumentType[]
 

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -171,7 +171,7 @@ export interface OrderPassenger {
 
 export interface OrderPassengerIdentityDocument {
   /**
-   * The type of the identity document. Currently, the only supported type is passport. This must be one of the allowed_passenger_identity_document_types on the offer.
+   * The type of the identity document. This must be one of the allowed_passenger_identity_document_types on the offer.
    */
   type: PassengerIdentityDocumentType
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -75,10 +75,10 @@ export type DuffelPassengerTitle = 'mr' | 'ms' | 'mrs' | 'MR' | 'MS' | 'MRS'
 export type DuffelPassengerGender = 'm' | 'f'
 
 /**
- * The type of the identity document. Currently, the only supported type is passport.
+ * The type of the identity document.
  * This must be one of the `allowed_passenger_identity_document_types` on the offer.
  */
-export type PassengerIdentityDocumentType = 'passport'
+export type PassengerIdentityDocumentType = 'passport' | 'tax_id'
 
 /**
  * The type of the origin or destination


### PR DESCRIPTION
Add tax_id to the list of identification documents that may be required for the booking.