### PR TITLE
feat(engine): update minimum require node.js version to 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
   node-executor:
     working_directory: *working_directory
     docker:
-      - image: cimg/node:14.21
+      - image: cimg/node:18.16
 
 commands:
   save_deps_cache:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,2 @@
-lts/fermium
+lts/hydrogen
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "typescript": "4.9.5"
   },
   "engines": {
-    "node": ">=14.*"
+    "node": ">=18.*"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
Node.js 14.x end of life was in April and we are updating our SDK to support Node.js 18.x as the minimum version. The reason we are not going first to 16, it's that EOL is in September.

Worth mentioning this is a breaking change for some users.