### PR TITLE
docs(readme): update README to include the minimum node.js version

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -13,7 +13,7 @@ A JavaScript client library for the Duffel API.
 
 ## Prerequisites
 
-- Node >= 14.17.6
+- Node >= 18.16.0
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,13 @@
         "@semantic-release/release-notes-generator"
       ],
       "@semantic-release/npm",
-      "@semantic-release/github"
+      [
+        "@semantic-release/github",
+        {
+          "successComment": false,
+          "failTitle": false
+        }
+      ]
     ],
     "branches": [
       "main"


### PR DESCRIPTION
On the previous PR, we missed updating the README to reflect the new Node.js engine.

➕ Extra change:
We were [rate limited](https://github.com/duffelhq/duffel-api-javascript/actions/runs/4881478277/jobs/8710431028) on GitHub API which caused our workflow to fail, this is due to an issue with semantic-release. I've disabled comments on issues to prevent this from happening.