### PR TITLE
fix(stays): update booking confirmed_at type to be non-nullable

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -448,9 +448,9 @@ export interface StaysBooking {
   status: StaysBookingStatus
 
   /**
-   * The ISO 8601 datetime at which the booking was confirmed by the accommodation.
+   * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) datetime at which the booking was made.
    */
-  confirmed_at: string | null
+  confirmed_at: string
 
   /**
    * The ISO 8601 datetime of the cancellation of this booking.


### PR DESCRIPTION
## 🔍 Overview

This PR fixes the `confirmed_at` field type to be non-nullable.