### PR TITLE
fix(stays): update list booking to return array

### DIFF
--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -54,7 +54,7 @@ export class Bookings extends Resource {
   /**
    * list bookings
    */
-  public list = async (): Promise<DuffelResponse<StaysBooking>> =>
+  public list = async (): Promise<DuffelResponse<StaysBooking[]>> =>
     this.request({
       method: 'GET',
       path: this.path,


### PR DESCRIPTION
## 🔍 Overview

This PR fixes the return type of the `stays.booking.list` to be an array.