### PR TITLE
build: switch to monthly dependency updates with renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
     "config:base",
     ":semanticCommits",
     ":semanticCommitTypeAll(build)",
-    "schedule:earlyMondays",
+    "schedule:monthly",
     ":combinePatchMinorReleases"
   ],
   "labels": ["dependencies"],


### PR DESCRIPTION
To reduce the time we spend on maintenance.