### PR TITLE
Adds loyalty types

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs lts-fermium
+nodejs lts-hydrogen

--- a/src/Stays/Bookings/Bookings.spec.ts
+++ b/src/Stays/Bookings/Bookings.spec.ts
@@ -13,6 +13,7 @@ describe('Stays/Bookings', () => {
     const mockResponse = { data: MOCK_BOOKING }
     const mockBookingParams: StaysBookingPayload = {
       quote_id: 'quo_123',
+      loyalty_programme_account_number: '123456789',
       guests: [
         {
           given_name: 'John',

--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -5,6 +5,7 @@ import { DuffelResponse } from '../../types'
 
 export interface StaysBookingPayload {
   quote_id: string
+  loyalty_programme_account_number?: string
   guests: Array<{
     given_name: string
     family_name: string

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -412,6 +412,28 @@ export interface StaysQuote {
    * Example: "GBP"
    */
   due_at_accommodation_currency: string
+
+  /**
+   * The loyalty programme that this quote supports.
+   */
+  supported_loyalty_programme:
+    | 'wyndham_rewards'
+    | 'choice_privileges'
+    | 'marriott_bonvoy'
+    | 'best_western_rewards'
+    | 'world_of_hyatt'
+    | 'hilton_honors'
+    | 'ihg_one_rewards'
+    | 'leaders_club'
+    | 'stash_rewards'
+    | 'omni_select_guest'
+    | 'i_prefer'
+    | 'accor_live_limitless'
+    | 'my_6'
+    | 'jumeirah_one'
+    | 'global_hotel_alliance_discovery'
+    | 'duffel_hotel_group_rewards'
+    | null
 }
 
 export type StaysBookingStatus = 'confirmed' | 'cancelled'

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -160,6 +160,7 @@ export const MOCK_BOOKING: StaysBooking = {
 
 export const MOCK_CREATE_BOOKING_PAYLOAD: StaysBookingPayload = {
   quote_id: 'quo_0000ARxBI85qTkbDDEZMO3',
+  loyalty_programme_account_number: '123456789',
   guests: [
     {
       given_name: 'Jean',
@@ -187,4 +188,5 @@ export const MOCK_QUOTE: StaysQuote = {
   tax_currency: 'USD',
   due_at_accommodation_amount: null,
   due_at_accommodation_currency: 'USD',
+  supported_loyalty_programme: 'duffel_hotel_group_rewards',
 }


### PR DESCRIPTION
__what__

Based on the [upcoming API](https://www.notion.so/Loyalty-Programmes-v1-Add-To-Booking-b81abdf4bb0d43b0965002596f485a57) to allow loyalty program account numbers to be sent along with the booking code, this PR adds the types for our API client.

Bonus: [updates tools version to match the engine on package json](https://github.com/duffelhq/duffel-api-javascript/commit/53671ed01d281262d4fcbeb64f2e18544c51a358)  