### PR TITLE
fix: add stays booking loyalty_programme_account_number

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -508,7 +508,12 @@ export interface StaysBooking {
     | null
 
   /**
-   * The number of rooms in the booking
+   * Loyalty account number to associate with this booking. Use this only when the quote has a supported_loyalty_programme indicated. Otherwise, this will result into an error.
+   */
+  loyalty_programme_account_number: string | null
+
+  /**
+   * The number of rooms in the booking.
    */
   rooms: number
 }

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -157,6 +157,7 @@ export const MOCK_BOOKING: StaysBooking = {
     },
   ],
   supported_loyalty_programme: null,
+  loyalty_programme_account_number: null,
   rooms: 1,
 }
 


### PR DESCRIPTION
Add the missing type for `loyalty_programme_account_number` from https://duffel.com/docs/api/v1/bookings/schema