### PR TITLE
fix: add new payment_method to stays rate

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -133,6 +133,11 @@ export interface StaysRate {
    * The currency of the total_amount, as an ISO 4217 currency code
    */
   total_currency: string
+
+  /**
+   * The method available for payment of this rate. A rate with the `balance` payment type will be paid for using your Duffel Balance, and a rate with the `card` payment type will be paid for with card details provided at time of booking.
+   */
+  payment_method: 'balance' | 'card'
 }
 
 export interface StaysPhoto {

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -46,6 +46,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
           fee_amount: '40.00',
           cancellation_timeline: [],
           board_type: 'room_only',
+          payment_method: 'balance',
         },
         {
           total_currency: 'GBP',
@@ -73,6 +74,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
           fee_amount: '40.00',
           cancellation_timeline: [],
           board_type: 'room_only',
+          payment_method: 'card',
         },
       ],
       photos: [


### PR DESCRIPTION
Companion to https://github.com/duffelhq/platform/pull/15548/files, should not be merged until that is.

Pre-requisite for dashboard changes in https://duffel.atlassian.net/browse/UXP-3088 to handle different payment methods for Stays.