### PR TITLE
Accommodation based search in Duffel Javascript SDK

### DIFF
--- a/src/Stays/Stays.spec.ts
+++ b/src/Stays/Stays.spec.ts
@@ -8,7 +8,7 @@ describe('Stays', () => {
     nock.cleanAll()
   })
 
-  it('should post to /stays/search when `search` is called', async () => {
+  it('should post location params to /stays/search when `search` is called', async () => {
     const mockResponse = { data: { results: [MOCK_SEARCH_RESULT] } }
     const mockSearchParams = {
       location: {
@@ -17,6 +17,29 @@ describe('Stays', () => {
           latitude: 40.73061,
           longitude: -73.935242,
         },
+      },
+      check_in_date: '2023-10-20',
+      check_out_date: '2023-10-24',
+      adults: 2,
+      rooms: 1,
+    }
+
+    nock(/(.*)/)
+      .post('/stays/search', (body) => {
+        expect(body.data).toEqual(mockSearchParams)
+        return true
+      })
+      .reply(200, mockResponse)
+    const response = await duffel.stays.search(mockSearchParams)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should post accommodation params to /stays/search when `search` is called', async () => {
+    const mockResponse = { data: { results: [MOCK_SEARCH_RESULT] } }
+    const mockSearchParams = {
+      accommodation: {
+        ids: ['acc_12345'],
+        fetch_rates: true,
       },
       check_in_date: '2023-10-20',
       check_out_date: '2023-10-24',

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -233,6 +233,11 @@ export interface StaysLocation {
 
 export interface StaysAccommodation {
   /**
+   * Duffel ID for this accommodation. Useful for searching availability
+   * for the same accommodation via accommodation based search.
+   */
+  id: string
+  /**
    * The amenities available at the accommodation
    */
   amenities: StaysAmenity[] | null
@@ -523,11 +528,14 @@ export interface StaysBooking {
   rooms: number
 }
 
-export interface StaysSearchParams {
+interface CommonStaysSearchParams {
   check_in_date: string
   check_out_date: string
   adults: number
   rooms: number
+}
+
+type LocationSearchParams = {
   location: {
     radius: number
     geographic_coordinates: {
@@ -535,7 +543,16 @@ export interface StaysSearchParams {
       longitude: number
     }
   }
-}
+} & CommonStaysSearchParams
+
+type AccommodationSearchParams = {
+  accommodation: {
+    ids: Array<string>
+    fetch_rates?: boolean
+  }
+} & CommonStaysSearchParams
+
+export type StaysSearchParams = LocationSearchParams | AccommodationSearchParams
 
 export interface StaysSearchResult {
   id: string

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -8,6 +8,7 @@ import {
 import { StaysBookingPayload } from './Bookings/Bookings'
 
 export const MOCK_ACCOMMODATION: StaysAccommodation = {
+  id: 'acc_0000AWr2VsUNIF1Vl91xg0',
   amenities: [
     { type: 'parking', description: 'Parking' },
     { type: 'wi-fi', description: 'Wi-Fi available' },


### PR DESCRIPTION
### What's here?

We have an upcoming release to search for accommodation.

This simply extends the types you can pass to Stays.search in the SDK to allow for accommodation based search.

This also makes sure that the SDK recognises the ID inside the accommodation as part of the main type.

### Where can I read more?

An updated guide is coming out soon, but for the mean time, a preview for the new parameters is [documented in our search documentation](https://duffel.com/docs/api/v1/search/stays-search#search-search-for-accommodation-body-parameters-accommodation)