### PR TITLE
Deprecate Stays.Booking.guest.born_on

### DIFF
--- a/src/Stays/Bookings/Bookings.spec.ts
+++ b/src/Stays/Bookings/Bookings.spec.ts
@@ -18,7 +18,6 @@ describe('Stays/Bookings', () => {
         {
           given_name: 'John',
           family_name: 'Smith',
-          born_on: '1980-01-01',
         },
       ],
       email: 'a@example.com',

--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -9,7 +9,6 @@ export interface StaysBookingPayload {
   guests: Array<{
     given_name: string
     family_name: string
-    born_on: string
   }>
   email: string
   phone_number: string

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -171,7 +171,6 @@ export const MOCK_CREATE_BOOKING_PAYLOAD: StaysBookingPayload = {
     {
       given_name: 'Jean',
       family_name: 'Gunnhildr',
-      born_on: '1994-03-14',
     },
   ],
   email: 'jean@example.com',


### PR DESCRIPTION
### What's here?

- We're about to deprecate Stays.Booking.guest.born_on from booking creation, so this is prepared once it's ready.