### PR TITLE
fix: fix seatmaps return type

### DIFF
--- a/src/booking/SeatMaps/SeatMaps.spec.ts
+++ b/src/booking/SeatMaps/SeatMaps.spec.ts
@@ -12,11 +12,11 @@ describe('SeatMaps', () => {
     const mockOfferId = 'off_123'
     nock(/(.*)/)
       .get(`/air/seat_maps?offer_id=${mockOfferId}`)
-      .reply(200, { data: mockSeatMap })
+      .reply(200, { data: [mockSeatMap] })
 
     const response = await new SeatMaps(new Client({ token: 'mockToken' })).get(
       { offer_id: mockOfferId }
     )
-    expect(response.data?.id).toBe(mockSeatMap.id)
+    expect(response.data[0].id).toBe(mockSeatMap.id)
   })
 })

--- a/src/booking/SeatMaps/SeatMaps.ts
+++ b/src/booking/SeatMaps/SeatMaps.ts
@@ -19,6 +19,6 @@ export class SeatMaps extends Resource {
    */
   public get = async (params: {
     offer_id: string
-  }): Promise<DuffelResponse<SeatMap>> =>
+  }): Promise<DuffelResponse<SeatMap[]>> =>
     this.request({ method: 'GET', path: `${this.path}`, params })
 }


### PR DESCRIPTION
Reading the [docs](https://duffel.com/docs/api/seat-maps/get-seat-maps), I'm pretty sure the return types should have been an array of seatmaps all along.