### PR TITLE
Adds missing `quantity_available` attribute 

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -140,6 +140,13 @@ export interface StaysRate {
   payment_method: 'balance' | 'card'
 }
 
+export interface StaysRoomRate extends StaysRate {
+  /**
+   * The quantity of rooms available to be booked at this rate. This number is not guaranteed to be accurate. Will be null if this information is unknown.
+   */
+  quantity_available: number
+}
+
 export interface StaysPhoto {
   url: string
 }
@@ -163,7 +170,7 @@ export interface StaysRoom {
   /**
    * The available rates for a specific room, including commission, distribution, payment and included services information.
    */
-  rates: StaysRate[]
+  rates: StaysRoomRate[]
 }
 
 export interface StaysAmenity {


### PR DESCRIPTION
__what__

To keep up with [documentation](https://duffel.com/docs/api/v1/search-result/fetch-all-rates#search-result-schema-accommodation-accommodation-rooms-accommodation-rooms-rates-accommodation-rooms-rates-quantity-available) and be able to surface this information on our dashboard (https://duffel.atlassian.net/browse/UXP-3181) this PR adds the missing attribute `quantity_available`.