### PR TITLE
fix: adds missing possible null value

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -144,7 +144,7 @@ export interface StaysRoomRate extends StaysRate {
   /**
    * The quantity of rooms available to be booked at this rate. This number is not guaranteed to be accurate. Will be null if this information is unknown.
    */
-  quantity_available: number
+  quantity_available: number | null
 }
 
 export interface StaysPhoto {


### PR DESCRIPTION
__what__

As @andrejak pointed out on [this comment](https://github.com/duffelhq/dashboard/pull/4599#discussion_r1342922984), the property could also be null. This adds the missing type. 