### PR TITLE
Use relative paths for the Client more consistently

### DIFF
--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -7,7 +7,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@duffel/api": "^1.9.5",
+    "@duffel/api": "^2.5.2",
     "classnames": "^2.3.1",
     "next": "^13.5.4",
     "react": "^18.2.0",

--- a/examples/with-next/yarn.lock
+++ b/examples/with-next/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@duffel/api@^1.9.5":
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/@duffel/api/-/api-1.9.5.tgz#62d8672d8790403c1d67824368c3eb86fd1fe396"
-  integrity sha512-akVHWYUBxA/LM6rU4t8w5nCiwIuYo2jzNfM59R+108yh8nYCcAhxqzBF+0NGJHUAVRv+uaIVpPNW8YzQWomfBw==
+"@duffel/api@^2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@duffel/api/-/api-2.5.2.tgz#082deb24b0cde94f7427d36555857e65647d7a1a"
+  integrity sha512-JA/1m/1kgSErssiH+xRFznu9D7TmciRwkOW4T8/rTxn09W+1Kso1FUjNPdOxaEabmmt2MYMvlm9EAFo/5L67XA==
   dependencies:
     "@types/node" "^17.0.21"
-    "@types/node-fetch" "^2.6.1"
-    node-fetch "2.6.7"
+    "@types/node-fetch" "^2.6.2"
+    node-fetch "2.6.11"
 
 "@next/env@13.5.4":
   version "13.5.4"
@@ -68,13 +68,13 @@
   dependencies:
     tslib "^2.4.0"
 
-"@types/node-fetch@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
-  integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
+"@types/node-fetch@^2.6.2":
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.6.tgz#b72f3f4bc0c0afee1c0bc9cff68e041d01e3e779"
+  integrity sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==
   dependencies:
     "@types/node" "*"
-    form-data "^3.0.0"
+    form-data "^4.0.0"
 
 "@types/node@*", "@types/node@^17.0.21":
   version "17.0.23"
@@ -156,10 +156,10 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -227,10 +227,10 @@ next@^13.5.4:
     "@next/swc-win32-ia32-msvc" "13.5.4"
     "@next/swc-win32-x64-msvc" "13.5.4"
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+node-fetch@2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 

--- a/src/Links/Sessions/Sessions.ts
+++ b/src/Links/Sessions/Sessions.ts
@@ -1,4 +1,4 @@
-import { Client } from 'Client'
+import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import { DuffelResponse } from '../../types'
 

--- a/src/Places/Suggestions/Suggestions.ts
+++ b/src/Places/Suggestions/Suggestions.ts
@@ -1,4 +1,4 @@
-import { Client } from 'Client'
+import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import { DuffelResponse, Places } from '../../types'
 

--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -1,4 +1,4 @@
-import { Client } from 'Client'
+import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import {
   CreateOfferRequest,

--- a/src/booking/Offers/Offers.ts
+++ b/src/booking/Offers/Offers.ts
@@ -1,4 +1,4 @@
-import { Client } from 'Client'
+import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import {
   DuffelResponse,

--- a/src/booking/PartialOfferRequests/PartialOfferRequests.ts
+++ b/src/booking/PartialOfferRequests/PartialOfferRequests.ts
@@ -1,4 +1,4 @@
-import { Client } from 'Client'
+import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import { CreateOfferRequest, DuffelResponse, OfferRequest } from '../../types'
 import { SelectedPartialOffersParams } from './PartialOfferRequestTypes'

--- a/src/notifications/Webhooks/Webhooks.ts
+++ b/src/notifications/Webhooks/Webhooks.ts
@@ -10,7 +10,7 @@ import {
   WebhooksUpdateParams,
 } from '../../types'
 import { Resource } from '../../Resource'
-import { Client } from 'Client'
+import { Client } from '../../Client'
 
 export class Webhooks extends Resource {
   /**


### PR DESCRIPTION
This PR changes a few Client imports that weren't using relative paths to match the rest, which will hopefully help resolve https://github.com/duffelhq/duffel-api-javascript/issues/794.

I also updated the version of the package in the example. I wasn't actually seeing this issue in the example, but I think it makes sense to keep it up to date.