### PR TITLE
fix: update typescript version in the repo and the example

### DIFF
--- a/examples/with-next/components/Card.tsx
+++ b/examples/with-next/components/Card.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 
 interface SharedProps {
   className?: string
+  children?: React.ReactNode
 }
 
 export const Root: FC<SharedProps> = ({ className, children }) => (

--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -17,6 +17,6 @@
     "@types/node": "^12.12.21",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "typescript": "^4.6.3"
+    "typescript": "^5.2.2"
   }
 }

--- a/examples/with-next/pages/api/book.ts
+++ b/examples/with-next/pages/api/book.ts
@@ -5,7 +5,7 @@ import { duffel } from '../../utils/duffel'
 const bookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { method } = req
 
-  if (method.toLowerCase() !== 'post') return res.status(404).end()
+  if (method?.toLowerCase() !== 'post') return res.status(404).end()
 
   const { passengers, offerId, currency, amount } = req.body
 

--- a/examples/with-next/pages/api/search.ts
+++ b/examples/with-next/pages/api/search.ts
@@ -11,7 +11,7 @@ function getTomorrow() {
 const searchHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { method } = req
 
-  if (method.toLowerCase() !== 'post') return res.status(404).end()
+  if (method?.toLowerCase() !== 'post') return res.status(404).end()
 
   const tomorrow = getTomorrow()
 

--- a/examples/with-next/pages/index.tsx
+++ b/examples/with-next/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Offer, Order } from '@duffel/api'
+import { Offer, Order } from '@duffel/api/types'
 import { NextPage } from 'next'
 import { FC, Fragment, useState } from 'react'
 import { Header } from '../components/Header'

--- a/examples/with-next/tsconfig.json
+++ b/examples/with-next/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,

--- a/examples/with-next/yarn.lock
+++ b/examples/with-next/yarn.lock
@@ -297,10 +297,10 @@ tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 watchpack@2.4.0:
   version "2.4.0"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "rollup-plugin-typescript2": "0.36.0",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
-    "typescript": "4.9.5"
+    "typescript": "5.2.2"
   },
   "engines": {
     "node": ">=18.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6375,10 +6375,10 @@ type-fest@^1.0.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-typescript@4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 typescript@^4.6.4:
   version "4.7.3"


### PR DESCRIPTION
This PR updates Typescript to 5.2.2 in both the repo and the associated example and fixes a couple associated warnings.