### PR TITLE
fix: consistently use relative imports for types

### DIFF
--- a/src/booking/AirlineInitiatedChanges/AirlineInitiatedChangesTypes.ts
+++ b/src/booking/AirlineInitiatedChanges/AirlineInitiatedChangesTypes.ts
@@ -1,4 +1,4 @@
-import { OrderSlice } from 'types'
+import { OrderSlice } from '../../types'
 
 export type AirlineInitiatedChangeActionTaken =
   | 'accepted'

--- a/src/booking/OfferRequests/OfferRequests.spec.ts
+++ b/src/booking/OfferRequests/OfferRequests.spec.ts
@@ -3,7 +3,7 @@ import { Client } from '../../Client'
 import { CreateOfferRequest, OfferRequest } from './OfferRequestsTypes'
 import { mockCreateOfferRequest, mockOfferRequest } from './mockOfferRequest'
 import { OfferRequests } from './OfferRequests'
-import { OfferPrivateFare } from 'types'
+import { OfferPrivateFare } from '../../types'
 
 describe('OfferRequests', () => {
   afterEach(() => {

--- a/src/notifications/Webhooks/WebhooksType.ts
+++ b/src/notifications/Webhooks/WebhooksType.ts
@@ -1,4 +1,4 @@
-import { PaginationMeta } from 'types'
+import { PaginationMeta } from '../../types'
 
 export interface Webhooks {
   /**


### PR DESCRIPTION
We use relative imports for `types` in most of the codebase, apart from these few instances. This PR makes that more consistent and should help with some recently seen TS issues.