### PR TITLE
fix: fix Airlines class declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "ansi-regex": "^5.0.1",
     "set-value": "^4.0.1",
     "minimist": "1.2.8",
-    "semver": "^7.5.3",
-    "word-wrap": "npm:@aashutoshrathi/word-wrap"
+    "semver": "^7.5.3"
   },
   "dependencies": {
     "@types/node": "^17.0.21",

--- a/src/supportingResources/Airlines/Airlines.ts
+++ b/src/supportingResources/Airlines/Airlines.ts
@@ -3,7 +3,8 @@ import { Airline, DuffelResponse, PaginationMeta } from '../../types'
 
 /** Airlines are used to identify the air travel companies selling and operating flights
  * @class
- * @link https://duffel.com/docs/api/airlines */
+ * @link https://duffel.com/docs/api/airlines
+ */
 export class Airlines extends Resource {
   /**
    * Endpoint path


### PR DESCRIPTION
This fixes the 2nd issue mentioned in https://github.com/duffelhq/duffel-api-javascript/issues/797. 

We were getting this error, only on the Airlines class:

```
node_modules/@duffel/api/dist/typings.d.ts:3921:12 - error TS1038: A 'declare' modifier cannot be used in an already ambient context.

3921     export declare class Airlines extends Resource {
```

I tried comparing the Airlines file to other similar ones (eg Airports). Making a small change in the doc comment about Airlines helped rebuild the typings file correctly on my machine so I'm hoping/assuming that will happen on the built one too...

<img width="584" alt="Screenshot 2023-10-13 at 10 17 55" src="https://github.com/duffelhq/duffel-api-javascript/assets/1416759/e137f0be-7344-4039-a598-b7d82b3a724e">

