### PR TITLE
use specific version for node

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs lts-hydrogen
+nodejs 18.18.2


### PR DESCRIPTION
__what__

Following [Norberto's lead](https://github.com/duffelhq/design-system/pull/465) and replicating this here:

> asdf no longer supports non-reproducible versions and they state that in the past that was by mistake not design. We shouldn't either.