### PR TITLE
fix: use expanded and up-to-date amenity types for Stays

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -200,7 +200,25 @@ export interface StaysRoom {
 
 export interface StaysAmenity {
   /* the type of amenity */
-  type: 'parking' | 'wi-fi' | 'gym'
+  type:
+    | 'parking'
+    | 'gym'
+    | 'wifi'
+    | '24_hour_front_desk'
+    | 'accessibility_hearing'
+    | 'accessibility_mobility'
+    | 'adult_only'
+    | 'business_centre'
+    | 'cash_machine'
+    | 'childcare_service'
+    | 'concierge'
+    | 'laundry'
+    | 'lounge'
+    | 'pets_allowed'
+    | 'pool'
+    | 'restaurant'
+    | 'room_service'
+    | 'spa'
   /* label friendly description of the amenity */
   description: string
 }

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -11,7 +11,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
   id: 'acc_0000AWr2VsUNIF1Vl91xg0',
   amenities: [
     { type: 'parking', description: 'Parking' },
-    { type: 'wi-fi', description: 'Wi-Fi available' },
+    { type: 'wifi', description: 'Wi-Fi available' },
     { type: 'gym', description: '24h Gym' },
   ],
   description:


### PR DESCRIPTION
### What's here?

Following our recent [announcement of expanded amenities](https://changelog.duffel.com/announcements/we-now-return-an-expanded-list-of-accommodation-amenities), we add the new ones to the list.

We also change wi-fi to wifi to enforce the same format across all amenity types.