### PR TITLE
Add cards tokenisation endpoint

### DIFF
--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -65,10 +65,10 @@ export class Bookings extends Resource {
    * @param {string} bookingId - The ID of the booking
    */
   public cancel = async (
-    bookindId: string,
+    bookingId: string,
   ): Promise<DuffelResponse<StaysBooking>> =>
     this.request({
       method: 'POST',
-      path: `${this.path}/${bookindId}/actions/cancel`,
+      path: `${this.path}/${bookingId}/actions/cancel`,
     })
 }

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -252,7 +252,7 @@ export interface StaysAddress {
   postal_code: string
 
   /**
-   * The setay's region or state
+   * The stay's region or state
    */
   region: string
 }

--- a/src/Vault/Cards/Cards.spec.ts
+++ b/src/Vault/Cards/Cards.spec.ts
@@ -1,0 +1,31 @@
+import nock from 'nock'
+import { Duffel } from '../../index'
+
+const duffel = new Duffel({ token: 'mockToken' })
+describe('Cards', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should create a card record when `create` is called', async () => {
+    const MOCK_ID = 'tcd_00009hthhsUZ8W4LxQgkjb'
+    nock(/(.*)/)
+      .post('/vault/cards')
+      .reply(200, { data: { id: MOCK_ID, liveMode: false } })
+
+    const response = await duffel.cards.create({
+      address_city: 'London',
+      address_country_code: 'GB',
+      address_line_1: '1 Downing St',
+      address_postal_code: 'EC2A 4RQ',
+      address_region: 'London',
+      brand: 'visa',
+      expiry_month: '03',
+      expiry_year: '30',
+      name: 'Neil Armstrong',
+      number: '4242424242424242',
+      cvc: '123',
+    })
+    expect(response.data.id).toBe(MOCK_ID)
+  })
+})

--- a/src/Vault/Cards/Cards.ts
+++ b/src/Vault/Cards/Cards.ts
@@ -1,0 +1,85 @@
+import { Client } from '../../Client'
+import { Resource } from '../../Resource'
+import { DuffelResponse } from '../../types'
+
+export type CardBrand =
+  | 'visa'
+  | 'mastercard'
+  | 'uatp'
+  | 'american_express'
+  | 'diners_club'
+  | 'jcb'
+
+interface CardParameters {
+  /**
+   * The first line of the card owner's address
+   */
+  address_line_1: string
+
+  /**
+   * The card owner's postal code (or zip code)
+   */
+  address_postal_code: string
+  /**
+   * The card owner's city
+   */
+  address_city: string
+  /**
+   * The card owner's region or state
+   */
+  address_region: string
+  /**
+   * The ISO 3166-1 alpha-2 code for the card owner's country
+   */
+  address_country_code: string
+  /**
+   * The brand or the type of the card
+   */
+  brand: CardBrand
+  /**
+   * The month that the card expires in as a two-digit string, e.g. "01"
+   */
+  expiry_month: string
+  /**
+   * The year that the card expires in as a two-digit string, e.g. "28"
+   */
+  expiry_year: string
+  /**
+   * The card owner's name
+   */
+  name: string
+  /**
+   * The card number
+   */
+  number: string
+  /**
+   * The card verification code
+   */
+  cvc: string
+}
+
+interface CardRecord {
+  id: string
+  live_mode: boolean
+}
+
+export class Cards extends Resource {
+  /**
+   * Endpoint path
+   */
+  path: string
+
+  // basePath must be 'https://api.duffel.cards'
+  constructor(client: Client) {
+    super(client)
+    this.path = 'vault/cards'
+  }
+
+  /**
+   * Create a Duffel card record
+   */
+  public create = async (
+    data: CardParameters,
+  ): Promise<DuffelResponse<CardRecord>> =>
+    this.request({ method: 'POST', path: this.path, data })
+}

--- a/src/Vault/Cards/index.ts
+++ b/src/Vault/Cards/index.ts
@@ -1,0 +1,1 @@
+export * from './Cards'

--- a/src/Vault/index.ts
+++ b/src/Vault/index.ts
@@ -1,0 +1,1 @@
+export * from './Cards'

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ import { Refunds } from './DuffelPayments/Refunds'
 import { Sessions } from './Links'
 import { Webhooks } from './notifications'
 import { Stays } from './Stays/Stays'
+import { Cards } from './Vault/Cards'
+
 export interface DuffelAPIClient {
   aircraft: Aircraft
   airlines: Airlines
@@ -57,6 +59,9 @@ export class Duffel {
   public webhooks: Webhooks
   public stays: Stays
 
+  private cardsClient: Client
+  public cards: Cards
+
   constructor(config: Config) {
     this.client = new Client(config)
 
@@ -80,6 +85,12 @@ export class Duffel {
     this.refunds = new Refunds(this.client)
     this.webhooks = new Webhooks(this.client)
     this.stays = new Stays(this.client)
+
+    this.cardsClient = new Client({
+      ...config,
+      basePath: 'https://api.duffel.cards',
+    })
+    this.cards = new Cards(this.cardsClient)
   }
 }
 


### PR DESCRIPTION
I've opened this up for review to get some feedback but some bits need a bit of tidying before actual release.

This is a prototype of how the cards tokenisation endpoint could work. Main difference is this lives on `duffel.api.cards` rather than `duffel.api.com`. 

I've put the code under Vault/Cards as the full URL is https://duffel.api.cards/vault/cards, but @igorp1 and I did discuss cleaning up that folder structure earlier today.

(I did test this worked with the next example inside the repo pointing to the local dist)