### PR TITLE
Booking payload type

### DIFF
--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -13,6 +13,7 @@ export interface StaysBookingPayload {
   email: string
   phone_number: string
   accommodation_special_requests?: string
+  payment?: { card_id: string }
 }
 
 export class Bookings extends Resource {


### PR DESCRIPTION
__what__

Adds missing type for booking payload to enable paying with card id.