### PR TITLE
fix: there's no type on the metadata object

### DIFF
--- a/src/booking/Offers/OfferTypes.ts
+++ b/src/booking/Offers/OfferTypes.ts
@@ -174,8 +174,8 @@ export interface OfferAvailableServiceCFARMetadata {
    * The amount the customer will receive back if the service is used, in
    * `offer.total_currency`.
    */
-
   refund_amount: string
+
   /**
    * Information to display to customers.
    */
@@ -185,8 +185,6 @@ export interface OfferAvailableServiceCFARMetadata {
    * URL with the T&Cs for customers.
    */
   terms_and_conditions_url: string
-
-  type: 'cancel_for_any_reason'
 }
 
 export interface OfferAvailableServiceCommon {

--- a/src/booking/Offers/mockOffer.ts
+++ b/src/booking/Offers/mockOffer.ts
@@ -205,7 +205,6 @@ export const mockOffer: Offer = {
         merchant_copy: 'some information for the merchant',
         refund_amount: '33.75',
         terms_and_conditions_url: 'this is a link',
-        type: 'cancel_for_any_reason',
       },
       passenger_ids: ['pas_00009hj8USM7Ncg31cBCL'],
       segment_ids: ['seg_00009htYpSCXrwaB9Dn456'],

--- a/src/booking/Offers/mockPartialOffer.ts
+++ b/src/booking/Offers/mockPartialOffer.ts
@@ -205,7 +205,6 @@ export const mockPartialOffer: Offer = {
         merchant_copy: 'some information for the merchant',
         refund_amount: '33.75',
         terms_and_conditions_url: 'this is a link',
-        type: 'cancel_for_any_reason',
       },
       passenger_ids: ['pas_00009hj8USM7Ncg31cBCL'],
       segment_ids: ['seg_00009htYpSCXrwaB9Dn456'],


### PR DESCRIPTION
__what__

This PR removes the `type` attribute from the metadata object.

 
<img width="746" alt="Screenshot 2023-12-11 at 3 30 53 PM" src="https://github.com/duffelhq/duffel-api-javascript/assets/2934495/0184c5b0-032c-49fc-bb7b-1077cf95452f">
