### PR TITLE
Add StaysRate.source

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -168,6 +168,12 @@ export interface StaysRate {
    * The duffel_hotel_group_rewards value is an example programme for testing and integration purposes, and will only appear on Duffel Hotel Group test hotel rates.
    */
   supported_loyalty_programme: StaysLoyaltyProgramme | null
+
+  /**
+   * The source of the rate.
+   * Useful in scenarios where a rate requires explicitly showing the source.
+   */
+  source: 'bookingcom' | 'priceline' | 'travelport' | 'duffel_hotel_group'
 }
 
 export interface StaysRoomRate extends StaysRate {

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -52,6 +52,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
           payment_method: 'balance',
           quantity_available: 1,
           supported_loyalty_programme: null,
+          source: 'duffel_hotel_group',
         },
         {
           total_currency: 'GBP',
@@ -82,6 +83,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
           payment_method: 'card',
           quantity_available: 1,
           supported_loyalty_programme: 'duffel_hotel_group_rewards',
+          source: 'duffel_hotel_group',
         },
       ],
       photos: [


### PR DESCRIPTION
### What's here?

- This is to prepare for upcoming Rate sources
- Mergeable once API is updated with corresponding values