### PR TITLE
fix: update airlines types to better match schema

### DIFF
--- a/src/booking/AirlineInitiatedChanges/mockAirlineInitiatedChanges.ts
+++ b/src/booking/AirlineInitiatedChanges/mockAirlineInitiatedChanges.ts
@@ -50,6 +50,8 @@ export const mockAirlineInitiatedChange: AirlineInitiatedChange = {
               'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
             id: 'arl_00009VME7DBKeMags5CliQ',
             iata_code: 'BA',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           marketing_carrier_flight_number: '0472',
           marketing_carrier: {
@@ -60,6 +62,8 @@ export const mockAirlineInitiatedChange: AirlineInitiatedChange = {
               'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
             id: 'arl_00009VME7DBKeMags5CliQ',
             iata_code: 'BA',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           id: 'seg_00009htYpSCXrwaB9Dn456',
           duration: 'PT2H10M',
@@ -173,6 +177,8 @@ export const mockAirlineInitiatedChange: AirlineInitiatedChange = {
               'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
             id: 'arl_00009VME7DBKeMags5CliQ',
             iata_code: 'BA',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           marketing_carrier_flight_number: '0474',
           marketing_carrier: {
@@ -183,6 +189,8 @@ export const mockAirlineInitiatedChange: AirlineInitiatedChange = {
               'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
             id: 'arl_00009VME7DBKeMags5CliQ',
             iata_code: 'BA',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           id: 'seg_00009htYpSCXrwaB9Dn457',
           duration: 'PT2H15M',

--- a/src/booking/Offers/mockOffer.ts
+++ b/src/booking/Offers/mockOffer.ts
@@ -48,12 +48,24 @@ export const mockOffer: Offer = {
             name: 'British Airways',
             id: 'aln_00001876aqC8c5umZmrRds',
             iata_code: 'BA',
+            logo_symbol_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+            logo_lockup_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           marketing_carrier_flight_number: '1234',
           marketing_carrier: {
             name: 'British Airways',
             id: 'aln_00001876aqC8c5umZmrRds',
             iata_code: 'BA',
+            logo_symbol_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+            logo_lockup_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           id: 'seg_00009htYpSCXrwaB9Dn456',
           duration: 'PT02H26M',
@@ -162,6 +174,12 @@ export const mockOffer: Offer = {
     name: 'British Airways',
     id: 'aln_00001876aqC8c5umZmrRds',
     iata_code: 'BA',
+    logo_symbol_url:
+      'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+    logo_lockup_url:
+      'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+    conditions_of_carriage_url:
+      'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
   },
   live_mode: true,
   id: 'off_00009htYpSCXrwaB9DnUm0',

--- a/src/booking/Offers/mockPartialOffer.ts
+++ b/src/booking/Offers/mockPartialOffer.ts
@@ -48,12 +48,24 @@ export const mockPartialOffer: Offer = {
             name: 'British Airways',
             id: 'aln_00001876aqC8c5umZmrRds',
             iata_code: 'BA',
+            logo_symbol_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+            logo_lockup_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           marketing_carrier_flight_number: '1234',
           marketing_carrier: {
             name: 'British Airways',
             id: 'aln_00001876aqC8c5umZmrRds',
             iata_code: 'BA',
+            logo_symbol_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+            logo_lockup_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           id: 'seg_00009htYpSCXrwaB9Dn456',
           duration: 'PT02H26M',
@@ -162,6 +174,12 @@ export const mockPartialOffer: Offer = {
     name: 'British Airways',
     id: 'aln_00001876aqC8c5umZmrRds',
     iata_code: 'BA',
+    logo_symbol_url:
+      'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+    logo_lockup_url:
+      'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+    conditions_of_carriage_url:
+      'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
   },
   live_mode: true,
   id: 'off_00009htYpSCXrwaB9DnUm0',

--- a/src/booking/OrderChangeOffers/mockOrderChangeOffer.ts
+++ b/src/booking/OrderChangeOffers/mockOrderChangeOffer.ts
@@ -30,12 +30,24 @@ export const mockOrderChangeOffer: OrderChangeOffer = {
               name: 'British Airways',
               id: 'aln_00001876aqC8c5umZmrRds',
               iata_code: 'BA',
+              logo_symbol_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+              logo_lockup_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+              conditions_of_carriage_url:
+                'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
             },
             marketing_carrier_flight_number: '1234',
             marketing_carrier: {
               name: 'British Airways',
               id: 'aln_00001876aqC8c5umZmrRds',
               iata_code: 'BA',
+              logo_symbol_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+              logo_lockup_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+              conditions_of_carriage_url:
+                'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
             },
             id: 'seg_00009htYpSCXrwaB9Dn456',
             duration: 'PT02H26M',
@@ -176,12 +188,24 @@ export const mockOrderChangeOffer: OrderChangeOffer = {
               name: 'British Airways',
               id: 'aln_00001876aqC8c5umZmrRds',
               iata_code: 'BA',
+              logo_symbol_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+              logo_lockup_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+              conditions_of_carriage_url:
+                'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
             },
             marketing_carrier_flight_number: '1234',
             marketing_carrier: {
               name: 'British Airways',
               id: 'aln_00001876aqC8c5umZmrRds',
               iata_code: 'BA',
+              logo_symbol_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+              logo_lockup_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+              conditions_of_carriage_url:
+                'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
             },
             id: 'seg_00009htYpSCXrwaB9Dn456',
             duration: 'PT02H26M',

--- a/src/booking/OrderChangeRequests/mockOrderChangeRequests.ts
+++ b/src/booking/OrderChangeRequests/mockOrderChangeRequests.ts
@@ -121,12 +121,24 @@ export const mockOrderChangeRequest: OrderChangeRequestResponse = {
                   name: 'British Airways',
                   id: 'aln_00001876aqC8c5umZmrRds',
                   iata_code: 'BA',
+                  logo_symbol_url:
+                    'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+                  logo_lockup_url:
+                    'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+                  conditions_of_carriage_url:
+                    'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
                 },
                 marketing_carrier_flight_number: '1234',
                 marketing_carrier: {
                   name: 'British Airways',
                   id: 'aln_00001876aqC8c5umZmrRds',
                   iata_code: 'BA',
+                  logo_symbol_url:
+                    'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+                  logo_lockup_url:
+                    'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+                  conditions_of_carriage_url:
+                    'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
                 },
                 id: 'seg_00009htYpSCXrwaB9Dn456',
                 duration: 'PT02H26M',
@@ -267,12 +279,24 @@ export const mockOrderChangeRequest: OrderChangeRequestResponse = {
                   name: 'British Airways',
                   id: 'aln_00001876aqC8c5umZmrRds',
                   iata_code: 'BA',
+                  logo_symbol_url:
+                    'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+                  logo_lockup_url:
+                    'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+                  conditions_of_carriage_url:
+                    'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
                 },
                 marketing_carrier_flight_number: '1234',
                 marketing_carrier: {
                   name: 'British Airways',
                   id: 'aln_00001876aqC8c5umZmrRds',
                   iata_code: 'BA',
+                  logo_symbol_url:
+                    'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+                  logo_lockup_url:
+                    'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+                  conditions_of_carriage_url:
+                    'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
                 },
                 id: 'seg_00009htYpSCXrwaB9Dn456',
                 duration: 'PT02H26M',

--- a/src/booking/OrderChanges/mockOrderChanges.ts
+++ b/src/booking/OrderChanges/mockOrderChanges.ts
@@ -29,12 +29,24 @@ export const mockOrderChange: OrderChange = {
               name: 'British Airways',
               id: 'aln_00001876aqC8c5umZmrRds',
               iata_code: 'BA',
+              logo_symbol_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+              logo_lockup_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+              conditions_of_carriage_url:
+                'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
             },
             marketing_carrier_flight_number: '1234',
             marketing_carrier: {
               name: 'British Airways',
               id: 'aln_00001876aqC8c5umZmrRds',
               iata_code: 'BA',
+              logo_symbol_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+              logo_lockup_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+              conditions_of_carriage_url:
+                'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
             },
             id: 'seg_00009htYpSCXrwaB9Dn456',
             duration: 'PT02H26M',
@@ -175,12 +187,24 @@ export const mockOrderChange: OrderChange = {
               name: 'British Airways',
               id: 'aln_00001876aqC8c5umZmrRds',
               iata_code: 'BA',
+              logo_symbol_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+              logo_lockup_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+              conditions_of_carriage_url:
+                'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
             },
             marketing_carrier_flight_number: '1234',
             marketing_carrier: {
               name: 'British Airways',
               id: 'aln_00001876aqC8c5umZmrRds',
               iata_code: 'BA',
+              logo_symbol_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+              logo_lockup_url:
+                'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+              conditions_of_carriage_url:
+                'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
             },
             id: 'seg_00009htYpSCXrwaB9Dn456',
             duration: 'PT02H26M',

--- a/src/booking/Orders/mockOrders.ts
+++ b/src/booking/Orders/mockOrders.ts
@@ -97,12 +97,24 @@ export const mockOrder: Order = {
             name: 'British Airways',
             id: 'aln_00001876aqC8c5umZmrRds',
             iata_code: 'BA',
+            logo_symbol_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+            logo_lockup_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           marketing_carrier_flight_number: '1234',
           marketing_carrier: {
             name: 'British Airways',
             id: 'aln_00001876aqC8c5umZmrRds',
             iata_code: 'BA',
+            logo_symbol_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+            logo_lockup_url:
+              'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+            conditions_of_carriage_url:
+              'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
           },
           id: 'seg_00009htYpSCXrwaB9Dn456',
           duration: 'PT02H26M',
@@ -222,6 +234,12 @@ export const mockOrder: Order = {
     name: 'British Airways',
     id: 'aln_00001876aqC8c5umZmrRds',
     iata_code: 'BA',
+    logo_symbol_url:
+      'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+    logo_lockup_url:
+      'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
+    conditions_of_carriage_url:
+      'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
   },
   metadata: {
     customer_prefs: 'window seat',
@@ -295,12 +313,18 @@ export const mockOnHoldOrders: Order[] = [
               name: 'American Airlines',
               id: 'arl_00009VME7DAGiJjwomhv32',
               iata_code: 'AA',
+              logo_lockup_url: null,
+              logo_symbol_url: null,
+              conditions_of_carriage_url: null,
             },
             marketing_carrier_flight_number: '4721',
             marketing_carrier: {
               name: 'American Airlines',
               id: 'arl_00009VME7DAGiJjwomhv32',
               iata_code: 'AA',
+              logo_lockup_url: null,
+              logo_symbol_url: null,
+              conditions_of_carriage_url: null,
             },
             id: 'seg_0000A6GioOO1UDbjb7nIi9',
             duration: 'PT2H45M',
@@ -396,6 +420,9 @@ export const mockOnHoldOrders: Order[] = [
       name: 'American Airlines',
       id: 'arl_00009VME7DAGiJjwomhv32',
       iata_code: 'AA',
+      logo_symbol_url: null,
+      logo_lockup_url: null,
+      conditions_of_carriage_url: null,
     },
     metadata: {
       customer_prefs: 'window seat',
@@ -454,12 +481,18 @@ export const mockOnHoldOrders: Order[] = [
               name: 'American Airlines',
               id: 'arl_00009VME7DAGiJjwomhv32',
               iata_code: 'AA',
+              logo_lockup_url: null,
+              logo_symbol_url: null,
+              conditions_of_carriage_url: null,
             },
             marketing_carrier_flight_number: '4341',
             marketing_carrier: {
               name: 'American Airlines',
               id: 'arl_00009VME7DAGiJjwomhv32',
               iata_code: 'AA',
+              logo_lockup_url: null,
+              logo_symbol_url: null,
+              conditions_of_carriage_url: null,
             },
             id: 'seg_0000A6GiZRU4WXtdZJrivU',
             duration: 'PT2H49M',
@@ -555,6 +588,9 @@ export const mockOnHoldOrders: Order[] = [
       name: 'American Airlines',
       id: 'arl_00009VME7DAGiJjwomhv32',
       iata_code: 'AA',
+      logo_symbol_url: null,
+      logo_lockup_url: null,
+      conditions_of_carriage_url: null,
     },
     metadata: {
       customer_prefs: 'window seat',

--- a/src/supportingResources/Airlines/AirlinesTypes.ts
+++ b/src/supportingResources/Airlines/AirlinesTypes.ts
@@ -14,13 +14,17 @@ export interface Airline {
   /*
    * The two-character IATA code for the airline. This may be null for non-IATA carriers.
    */
-  iata_code: string
+  iata_code: string | null
   /*
    * Path to a svg of the airline lockup logo. A lockup logo is also called a combination logo, in which it combines the logotype and logomark. This may be `null` if no logo is available.
    */
-  logo_lockup_url?: string
+  logo_lockup_url: string | null
   /*
    * Path to a svg of the airline logo. This may be `null` if no logo is available.
    */
-  logo_symbol_url?: string
+  logo_symbol_url: string | null
+  /*
+   * URL to the airline's conditions of carriage.
+   */
+  conditions_of_carriage_url: string | null
 }

--- a/src/supportingResources/Airlines/mockAirline.ts
+++ b/src/supportingResources/Airlines/mockAirline.ts
@@ -8,4 +8,6 @@ export const mockAirline: Airline = {
     'https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg',
   logo_symbol_url:
     'https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg',
+  conditions_of_carriage_url:
+    'https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage',
 }


### PR DESCRIPTION
Add missing conditions of carriage and also noticed iata_code might not be present: https://duffel.com/docs/api/airlines/schema
In the repo we're a bit inconsistent with nullable vs optional properties but let me know if you'd prefer me to keep the existing way in this file.