### PR TITLE
add supplier timeout support

### DIFF
--- a/src/booking/OfferRequests/OfferRequests.ts
+++ b/src/booking/OfferRequests/OfferRequests.ts
@@ -73,7 +73,7 @@ export class OfferRequests extends Resource {
         : OfferRequest
     >
   > => {
-    const { return_offers, ...data } = options
+    const { return_offers, supplier_timeout, ...data } = options
 
     return this.request({
       method: 'POST',
@@ -82,6 +82,8 @@ export class OfferRequests extends Resource {
       params: {
         ...(return_offers !== undefined &&
           return_offers !== null && { return_offers }),
+        ...(supplier_timeout !== undefined &&
+          supplier_timeout !== null && { supplier_timeout }),
       },
     })
   }

--- a/src/booking/OfferRequests/OfferRequestsTypes.ts
+++ b/src/booking/OfferRequests/OfferRequestsTypes.ts
@@ -302,4 +302,18 @@ export interface CreateOfferRequestQueryParameters {
    * You should use this option if you want to take advantage of the pagination, sorting and filtering that the [List Offers](https://duffel.com/docs/api/offers/get-offers) endpoint provides.
    */
   return_offers?: boolean
+
+  /**
+   * The maximum amount of time in milliseconds to wait for each airline search to complete.
+   * This timeout applies to the response time of the call to the airline and includes
+   * some additional overhead added by Duffel. Value should be between `2` seconds and `60` seconds.
+   * Any values outside the range will be ignored and the default supplier_timeout will be used.
+   * If a value is set, the response will only include offers from airline searches that completed
+   * within the given time. If a value is not set, the response will only include offers from
+   * airline searches that completed within the default supplier_timeout value of 20 seconds.
+   * We recommend setting supplier_timeout lower than the timeout on the HTTP request you send to
+   * Duffel API as that will allow us to respond with the offers we received before your request
+   * times out with an empty response.
+   */
+  supplier_timeout?: number
 }

--- a/src/booking/PartialOfferRequests/PartialOfferRequestTypes.ts
+++ b/src/booking/PartialOfferRequests/PartialOfferRequestTypes.ts
@@ -4,3 +4,19 @@ export interface SelectedPartialOffersParams {
    */
   'selected_partial_offer[]'?: string[]
 }
+
+export interface CreatePartialOfferRequestQueryParam {
+  /**
+   * The maximum amount of time in milliseconds to wait for each airline search to complete.
+   * This timeout applies to the response time of the call to the airline and includes
+   * some additional overhead added by Duffel. Value should be between `2` seconds and `60` seconds.
+   * Any values outside the range will be ignored and the default supplier_timeout will be used.
+   * If a value is set, the response will only include offers from airline searches that completed
+   * within the given time. If a value is not set, the response will only include offers from
+   * airline searches that completed within the default supplier_timeout value of 20 seconds.
+   * We recommend setting supplier_timeout lower than the timeout on the HTTP request you send to
+   * Duffel API as that will allow us to respond with the offers we received before your request
+   * times out with an empty response.
+   */
+  supplier_timeout?: number
+}

--- a/src/booking/PartialOfferRequests/PartialOfferRequests.ts
+++ b/src/booking/PartialOfferRequests/PartialOfferRequests.ts
@@ -1,7 +1,10 @@
 import { Client } from '../../Client'
 import { Resource } from '../../Resource'
 import { CreateOfferRequest, DuffelResponse, OfferRequest } from '../../types'
-import { SelectedPartialOffersParams } from './PartialOfferRequestTypes'
+import {
+  CreatePartialOfferRequestQueryParam,
+  SelectedPartialOffersParams,
+} from './PartialOfferRequestTypes'
 
 /**
  * To search for and select flights separately for each slice of the journey, you'll need to create a partial offer request.
@@ -45,13 +48,20 @@ export class PartialOfferRequests extends Resource {
    * @param {Object} [options] - the parameters for making a partial offer requests (required: slices, passengers; optional: cabin_class)
    * @link https://duffel.com/docs/api/partial-offer-requests/create-partial-offer-request
    */
-  public create = async <QueryParams>(
+  public create = async <
+    QueryParams extends CreatePartialOfferRequestQueryParam,
+  >(
     options: CreateOfferRequest & QueryParams,
   ): Promise<DuffelResponse<OfferRequest>> => {
+    const { supplier_timeout, ...data } = options
     return this.request({
       method: 'POST',
       path: `${this.path}/`,
-      data: options,
+      data: data,
+      params: {
+        ...(supplier_timeout !== undefined &&
+          supplier_timeout !== null && { supplier_timeout }),
+      },
     })
   }
 


### PR DESCRIPTION
__what__

Includes [supplier timeout](https://duffel.com/docs/api/v1/offer-requests/create-offer-request#offer-requests-create-an-offer-request-query-parameters-supplier-timeout) to offer request creation functions.