### PR TITLE
fix: passenger titles

### DIFF
--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -67,7 +67,7 @@ export type DuffelPassengerType = 'adult' | 'child' | 'infant_without_seat'
 /**
  * The passenger's title
  */
-export type DuffelPassengerTitle = 'mr' | 'ms' | 'mrs' | 'MR' | 'MS' | 'MRS'
+export type DuffelPassengerTitle = 'mr' | 'ms' | 'mrs' | 'miss' | 'dr'
 
 /**
  * The passenger's gender


### PR DESCRIPTION
As reported in https://github.com/duffelhq/duffel-api-javascript/issues/886 our passenger title types were not matching the documentation. This PR fixes that.
Docs here: https://duffel.com/docs/api/v1/orders/create-order#orders-create-an-order-body-parameters-passengers-passengers-title