### PR TITLE
feat: add key collection to Accommodation

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -335,6 +335,11 @@ export interface StaysAccommodation {
   } | null
 
   /**
+   * Deprecated: Instructions to access the accommodation in the booking
+   */
+  key_collection: StaysBookingKeyCollection | null
+
+  /**
    * The total currency for the cheapest rate for this accommodation, as an ISO 4217 currency code. If rooms data is available, this is equivalent to the cheapest rate for the cheapest room.
    */
   cheapest_rate_currency: string
@@ -596,7 +601,7 @@ export interface StaysBooking {
   rooms: number
 
   /**
-   * Instructions to access the accommodation in the booking
+   * Deprecated: Instructions to access the accommodation in the booking
    */
   key_collection: StaysBookingKeyCollection | null
 }

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -140,6 +140,9 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
     check_out_before_time: '11:30',
     check_in_after_time: '14:30',
   },
+  key_collection: {
+    instructions: 'Key is at the property. Collect from the lock box.',
+  },
   cheapest_rate_total_amount: '799.00',
   cheapest_rate_currency: 'GBP',
   chain: {


### PR DESCRIPTION
The key collection was initially introduced to the Booking object,
but more integrations we add, it seems the best should be at Accommodation.

The key collection on Booking is deprecated, now the key collection exists in
Accommodation as preview.
