### PR TITLE
fix: rollup/plugin-terser reference

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { terser } from 'rollup-plugin-terser'
+import { terser } from '@rollup/plugin-terser'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'


### PR DESCRIPTION
Merging this [dependency update ](https://github.com/duffelhq/duffel-api-javascript/pull/900)caused a build failure: https://github.com/duffelhq/duffel-api-javascript/actions/runs/8685349505/job/23814635745
I think this should fix it.