### PR TITLE
fix: Fix import for @rollup/plugin-terser

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { terser } from '@rollup/plugin-terser'
+import terser from '@rollup/plugin-terser'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'


### PR DESCRIPTION
Version 0.1.0 exports `default`, rather than `terser`