### PR TITLE
fix: specify a more precise type for DuffelError headers

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch'
+import fetch, { Headers } from 'node-fetch'
 import { URL, URLSearchParams } from 'url'
 import {
   DuffelResponse,
@@ -18,7 +18,7 @@ export interface Config {
 export class DuffelError extends Error {
   public meta: ApiResponseMeta
   public errors: ApiResponseError[]
-  public headers: Record<string, string>
+  public headers: Headers
 
   constructor({
     meta,
@@ -27,7 +27,7 @@ export class DuffelError extends Error {
   }: {
     meta: ApiResponseMeta
     errors: ApiResponseError[]
-    headers: Record<string, string>
+    headers: Headers
   }) {
     super()
     this.meta = meta


### PR DESCRIPTION
Client creates DuffelError with headers directly passed from `fetch`. Even though headers satisfy `Record<string, string>`, that type isn't usable in practice for consumers of the library, e.g. when checking rate limit headers, — `Headers` is more precise.