### PR TITLE
Allow SDK to call stays accommodation endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/Accommodation/Accommodation.spec.ts
+++ b/src/Stays/Accommodation/Accommodation.spec.ts
@@ -1,0 +1,25 @@
+import nock from 'nock'
+import { Duffel } from '../../index'
+import { MOCK_ACCOMMODATION_SUGGESTION } from '../mocks'
+
+const duffel = new Duffel({ token: 'mockToken' })
+describe('Stays/Accommodation', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should post to /stays/suggestions when `suggestions` is called', async () => {
+    const query = 'rits'
+    const mockResponse = { data: [MOCK_ACCOMMODATION_SUGGESTION] }
+
+    nock(/(.*)/)
+      .post('/stays/accommodation/suggestions', (body) => {
+        expect(body.data.query).toEqual(query)
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.accommodation.suggestions(query)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+})

--- a/src/Stays/Accommodation/Accommodation.ts
+++ b/src/Stays/Accommodation/Accommodation.ts
@@ -15,8 +15,8 @@ export class Accommodation extends Resource {
   }
 
   /**
-   * Create a booking
-   * @param {object} payload - The booking payload, including quote id and guest information
+   * Get suggestions for accommodation given a query string.
+   * @param {string} query - The query string for the search
    */
   public suggestions = async (
     query: string,

--- a/src/Stays/Accommodation/Accommodation.ts
+++ b/src/Stays/Accommodation/Accommodation.ts
@@ -1,0 +1,31 @@
+import { Client } from '../../Client'
+import { StaysAccommodationSuggestion } from '../StaysTypes'
+import { Resource } from '../../Resource'
+import { DuffelResponse } from '../../types'
+
+export class Accommodation extends Resource {
+  /**
+   * Endpoint path
+   */
+  path: string
+
+  constructor(client: Client) {
+    super(client)
+    this.path = 'stays/accommodation'
+  }
+
+  /**
+   * Create a booking
+   * @param {object} payload - The booking payload, including quote id and guest information
+   */
+  public suggestions = async (
+    query: string,
+  ): Promise<DuffelResponse<StaysAccommodationSuggestion[]>> =>
+    this.request({
+      method: 'POST',
+      path: `${this.path}/suggestions`,
+      data: {
+        query: query,
+      },
+    })
+}

--- a/src/Stays/Accommodation/index.ts
+++ b/src/Stays/Accommodation/index.ts
@@ -1,0 +1,1 @@
+export * from './Accommodation'

--- a/src/Stays/Stays.ts
+++ b/src/Stays/Stays.ts
@@ -2,6 +2,7 @@ import { Client } from '../Client'
 import { StaysSearchParams, StaysSearchResult } from './StaysTypes'
 import { Resource } from '../Resource'
 import { DuffelResponse } from '../types'
+import { Accommodation } from './Accommodation'
 import { Bookings } from './Bookings'
 import { Quotes } from './Quotes'
 import { SearchResults } from './SearchResults'
@@ -12,6 +13,7 @@ export class Stays extends Resource {
    */
   path: string
 
+  public accommodation: Accommodation
   public searchResults: SearchResults
   public quotes: Quotes
   public bookings: Bookings
@@ -20,6 +22,7 @@ export class Stays extends Resource {
     super(client)
     this.path = 'stays'
 
+    this.accommodation = new Accommodation(client)
     this.searchResults = new SearchResults(client)
     this.quotes = new Quotes(client)
     this.bookings = new Bookings(client)

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -400,6 +400,12 @@ export interface StaysAccommodation {
   rooms: StaysRoom[]
 }
 
+export interface StaysAccommodationSuggestion {
+  accommodation_id: StaysAccommodation['id']
+  accommodation_name: StaysAccommodation['name']
+  accommodation_location: StaysLocation
+}
+
 /**
  * Represents a quote for a stay.
  */

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -1,6 +1,7 @@
 // eslint-disable spellcheck/spell-checker
 import {
   StaysAccommodation,
+  StaysAccommodationSuggestion,
   StaysBooking,
   StaysQuote,
   StaysSearchResult,
@@ -217,4 +218,10 @@ export const MOCK_QUOTE: StaysQuote = {
   adults: 2,
   rooms: 1,
   guests: [{ type: 'adult' }, { type: 'adult' }],
+}
+
+export const MOCK_ACCOMMODATION_SUGGESTION: StaysAccommodationSuggestion = {
+  accommodation_id: MOCK_ACCOMMODATION.id,
+  accommodation_name: MOCK_ACCOMMODATION.name,
+  accommodation_location: MOCK_ACCOMMODATION.location,
 }


### PR DESCRIPTION
### What's here?

- This adds an `accommodation` property to the main Stays object.
- It is initialised with the suggestions function
- A new type, AccommodationSuggestions is introduced. This is an excerpt of the larger Accommodation object.