### PR TITLE
Implement SDK call for accommodation/{id}

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/Accommodation/Accommodation.spec.ts
+++ b/src/Stays/Accommodation/Accommodation.spec.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import { Duffel } from '../../index'
-import { MOCK_ACCOMMODATION_SUGGESTION } from '../mocks'
+import { MOCK_ACCOMMODATION_SUGGESTION, MOCK_ACCOMMODATION } from '../mocks'
 
 const duffel = new Duffel({ token: 'mockToken' })
 describe('Stays/Accommodation', () => {
@@ -20,6 +20,20 @@ describe('Stays/Accommodation', () => {
       .reply(200, mockResponse)
 
     const response = await duffel.stays.accommodation.suggestions(query)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should send GET to /stays/{id} when `get` is called', async () => {
+    const id = MOCK_ACCOMMODATION.id
+    const mockResponse = { data: MOCK_ACCOMMODATION }
+
+    nock(/(.*)/)
+      .get(`/stays/accommodation/${id}`, () => {
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.accommodation.get(id)
     expect(response.data).toEqual(mockResponse.data)
   })
 })

--- a/src/Stays/Accommodation/Accommodation.ts
+++ b/src/Stays/Accommodation/Accommodation.ts
@@ -1,5 +1,5 @@
 import { Client } from '../../Client'
-import { StaysAccommodationSuggestion } from '../StaysTypes'
+import { StaysAccommodationSuggestion, StaysAccommodation } from '../StaysTypes'
 import { Resource } from '../../Resource'
 import { DuffelResponse } from '../../types'
 
@@ -27,5 +27,17 @@ export class Accommodation extends Resource {
       data: {
         query: query,
       },
+    })
+
+  /**
+   * Get information about an accommodation with a specific Duffel ID
+   * @param {string} id - The Duffel ID of the Accommodation
+   */
+  public get = async (
+    id: StaysAccommodation['id'],
+  ): Promise<DuffelResponse<StaysAccommodation>> =>
+    this.request({
+      method: 'GET',
+      path: `${this.path}/${id}`,
     })
 }


### PR DESCRIPTION
### What's here?

This adds one more accommodation fetch call. It takes a specific Duffel ID and returns a stays accommodation.

### References

To learn more about the endpoint being called in this PR, some documentation about GET `/stays/accommodation/{id}` can be found here:

https://duffel.com/docs/api/v1/accommodation/get-accommodation