### PR TITLE
ci: remove UXP as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # See https://help.github.com/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 # for more information about the format and syntax of this file
 
-* @duffelhq/ux-products
+* @duffelhq/engineering


### PR DESCRIPTION
Context here: https://duffel.slack.com/archives/CEA36CWLX/p1719225090881319