### PR TITLE
Add optional location parameter to suggestions SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/Accommodation/Accommodation.spec.ts
+++ b/src/Stays/Accommodation/Accommodation.spec.ts
@@ -10,11 +10,37 @@ describe('Stays/Accommodation', () => {
 
   it('should post to /stays/suggestions when `suggestions` is called', async () => {
     const query = 'rits'
+    const location = {
+      geographic_coordinates: { latitude: 51.5287398, longitude: -0.2664005 },
+      radius: 5,
+    }
+
     const mockResponse = { data: [MOCK_ACCOMMODATION_SUGGESTION] }
 
     nock(/(.*)/)
       .post('/stays/accommodation/suggestions', (body) => {
         expect(body.data.query).toEqual(query)
+        expect(body.data.location).toEqual(location)
+
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.accommodation.suggestions(
+      query,
+      location,
+    )
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should post to /stays/suggestions without a location when `suggestions` is called with only a query', async () => {
+    const query = 'rits'
+    const mockResponse = { data: [MOCK_ACCOMMODATION_SUGGESTION] }
+
+    nock(/(.*)/)
+      .post('/stays/accommodation/suggestions', (body) => {
+        expect(body.data.query).toEqual(query)
+        expect(body.data.location).toBeUndefined()
         return true
       })
       .reply(200, mockResponse)

--- a/src/Stays/Accommodation/Accommodation.ts
+++ b/src/Stays/Accommodation/Accommodation.ts
@@ -1,5 +1,9 @@
 import { Client } from '../../Client'
-import { StaysAccommodationSuggestion, StaysAccommodation } from '../StaysTypes'
+import {
+  LocationParams,
+  StaysAccommodationSuggestion,
+  StaysAccommodation,
+} from '../StaysTypes'
 import { Resource } from '../../Resource'
 import { DuffelResponse } from '../../types'
 
@@ -20,12 +24,14 @@ export class Accommodation extends Resource {
    */
   public suggestions = async (
     query: string,
+    location?: LocationParams,
   ): Promise<DuffelResponse<StaysAccommodationSuggestion[]>> =>
     this.request({
       method: 'POST',
       path: `${this.path}/suggestions`,
       data: {
         query: query,
+        location: location,
       },
     })
 

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -633,14 +633,16 @@ type CommonStaysSearchParams = {
   check_out_date: string
 } & OccupancyCriteria
 
-type LocationSearchParams = {
-  location: {
-    radius: number
-    geographic_coordinates: {
-      latitude: number
-      longitude: number
-    }
+export type LocationParams = {
+  radius: number
+  geographic_coordinates: {
+    latitude: number
+    longitude: number
   }
+}
+
+type LocationSearchParams = {
+  location: LocationParams
 } & CommonStaysSearchParams
 
 type AccommodationSearchParams = {


### PR DESCRIPTION
### What's here?

This patches the current suggestions SDK kit to be able to receive an optional location. 

It will restrict suggestions only to said location when supplied.