### PR TITLE
chore: update `package.json` metadata to improve Dependabot PRs for this package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "types": "dist/typings.d.ts",
-  "homepage": "https://duffel.com",
+  "homepage": "https://github.com/duffelhq/duffel-api-javascript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/duffelhq/duffel-api-javascript.git"
+  },
   "keywords": [
     "duffel"
   ],


### PR DESCRIPTION
At the moment, Dependabot pull requests for `@duffel/api` are not very helpful, because (a) they don't include a changelog and (b) the link points to the Duffel homepage ([example][1]).

For most packages, you get a much more helpful PR body which tells you about the changes and lets you easily navigate to the repo ([example][2]).

To improve this, this updates the `homepage` metadata in `package.json` to point to the repo instead of `https://duffel. com`, and it adds `repository` metadata.

This should be picked up by Dependabot (code [here][3]) to enable a much better experience!

[1]: https://github.com/timrogers/iata-code-decoder-api/pull/550
[2]: https://github.com/timrogers/iata-code-decoder-api/pull/548
[3]: https://github.com/dependabot/dependabot-core/blob/a35b58ba591bc50e30ac07e727d081e573fe7dbe/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb