### PR TITLE
feat: add stays loyalty programmes resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/LoyaltyProgrammes/LoyaltyProgrammes.spec.ts
+++ b/src/Stays/LoyaltyProgrammes/LoyaltyProgrammes.spec.ts
@@ -1,0 +1,20 @@
+import nock from 'nock'
+import { Duffel } from '../../index'
+import { MOCK_LOYALTY_PROGRAMMES } from '../mocks'
+
+const duffel = new Duffel({ token: 'mockToken' })
+describe('Stays/LoyaltyProgrammes', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should send a get to /stays/loyalty_programmes when `list` is called', async () => {
+    const mockResponse = { data: MOCK_LOYALTY_PROGRAMMES }
+
+    nock(/(.*)/).get('/stays/loyalty_programmes').reply(200, mockResponse)
+
+    const response = await duffel.stays.loyaltyProgrammes.list()
+
+    expect(response.data).toEqual(mockResponse.data)
+  })
+})

--- a/src/Stays/LoyaltyProgrammes/LoyaltyProgrammes.ts
+++ b/src/Stays/LoyaltyProgrammes/LoyaltyProgrammes.ts
@@ -1,0 +1,25 @@
+import { Client } from '../../Client'
+import { StaysLoyaltyProgramme } from '../StaysTypes'
+import { Resource } from '../../Resource'
+import { DuffelResponse } from '../../types'
+
+export class LoyaltyProgrammes extends Resource {
+  /**
+   * Endpoint path
+   */
+  path: string
+
+  constructor(client: Client) {
+    super(client)
+    this.path = 'stays/loyalty_programmes'
+  }
+
+  /**
+   * List all the loyalty programmes supported by Duffel Stays
+   */
+  public list = async (): Promise<DuffelResponse<StaysLoyaltyProgramme[]>> =>
+    this.request({
+      method: 'GET',
+      path: this.path,
+    })
+}

--- a/src/Stays/LoyaltyProgrammes/index.ts
+++ b/src/Stays/LoyaltyProgrammes/index.ts
@@ -1,0 +1,1 @@
+export * from './LoyaltyProgrammes'

--- a/src/Stays/Stays.ts
+++ b/src/Stays/Stays.ts
@@ -3,6 +3,7 @@ import { StaysSearchParams, StaysSearchResult } from './StaysTypes'
 import { Resource } from '../Resource'
 import { DuffelResponse } from '../types'
 import { Accommodation } from './Accommodation'
+import { LoyaltyProgrammes } from './LoyaltyProgrammes'
 import { Bookings } from './Bookings'
 import { Quotes } from './Quotes'
 import { SearchResults } from './SearchResults'
@@ -14,6 +15,7 @@ export class Stays extends Resource {
   path: string
 
   public accommodation: Accommodation
+  public loyaltyProgrammes: LoyaltyProgrammes
   public searchResults: SearchResults
   public quotes: Quotes
   public bookings: Bookings
@@ -23,6 +25,7 @@ export class Stays extends Resource {
     this.path = 'stays'
 
     this.accommodation = new Accommodation(client)
+    this.loyaltyProgrammes = new LoyaltyProgrammes(client)
     this.searchResults = new SearchResults(client)
     this.quotes = new Quotes(client)
     this.bookings = new Bookings(client)

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -53,7 +53,7 @@ export interface StaysRateCancellationTimeline {
   currency: string
 }
 
-export type StaysLoyaltyProgramme =
+export type StaysLoyaltyProgrammeReference =
   | 'wyndham_rewards'
   | 'choice_privileges'
   | 'marriott_bonvoy'
@@ -178,7 +178,7 @@ export interface StaysRate {
    * If the rate does not support a loyalty programme, this will be null.
    * The duffel_hotel_group_rewards value is an example programme for testing and integration purposes, and will only appear on Duffel Hotel Group test hotel rates.
    */
-  supported_loyalty_programme: StaysLoyaltyProgramme | null
+  supported_loyalty_programme: StaysLoyaltyProgrammeReference | null
 
   /**
    * The source of the rate.
@@ -398,6 +398,11 @@ export interface StaysAccommodation {
    * Rooms for the accommodation
    */
   rooms: StaysRoom[]
+
+  /**
+   * The loyalty programme that this accommodation supports.
+   */
+  supported_loyalty_programme: StaysLoyaltyProgrammeReference | null
 }
 
 export interface StaysAccommodationSuggestion {
@@ -519,7 +524,7 @@ export interface StaysQuote {
   /**
    * The loyalty programme that this quote supports.
    */
-  supported_loyalty_programme: StaysLoyaltyProgramme | null
+  supported_loyalty_programme: StaysLoyaltyProgrammeReference | null
 
   /**
    * A client key to authenticate with Duffel's Card Component when creating a tokenised card.
@@ -600,7 +605,7 @@ export interface StaysBooking {
   /**
    * The loyalty programme that this booking supports.
    */
-  supported_loyalty_programme: StaysLoyaltyProgramme | null
+  supported_loyalty_programme: StaysLoyaltyProgrammeReference | null
 
   /**
    * Loyalty account number to associate with this booking. Use this only when the quote has a supported_loyalty_programme indicated. Otherwise, this will result into an error.
@@ -667,4 +672,10 @@ export interface StaysSearchResult {
   adults: number
   rooms: number
   guests: Array<Guest>
+}
+
+export interface StaysLoyaltyProgramme {
+  reference: StaysLoyaltyProgrammeReference
+  name: string
+  logo_url: string | null
 }

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -3,6 +3,7 @@ import {
   StaysAccommodation,
   StaysAccommodationSuggestion,
   StaysBooking,
+  StaysLoyaltyProgramme,
   StaysQuote,
   StaysSearchResult,
 } from './StaysTypes'
@@ -149,6 +150,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
   chain: {
     name: 'The Ritz-Carlton',
   },
+  supported_loyalty_programme: 'duffel_hotel_group_rewards',
 }
 
 export const MOCK_SEARCH_RESULT: StaysSearchResult = {
@@ -228,3 +230,12 @@ export const MOCK_ACCOMMODATION_SUGGESTION: StaysAccommodationSuggestion = {
   accommodation_name: MOCK_ACCOMMODATION.name,
   accommodation_location: MOCK_ACCOMMODATION.location,
 }
+
+export const MOCK_LOYALTY_PROGRAMMES: StaysLoyaltyProgramme[] = [
+  {
+    reference: 'duffel_hotel_group_rewards',
+    name: 'Duffel Hotel Group Rewards',
+    logo_url:
+      'https://assets.duffel.com/img/stays/loyalty-programmes/full-color-logo/duffel_hotel_group_rewards-square.svg',
+  },
+]


### PR DESCRIPTION
## What's here?
This adds the Loyalty Programmes resource to the SDK. This allows fetching of information about the loyalty programmes supported by Accommodation or Rates. 

## References
To learn more about the endpoint being called in this PR, the Stays loyalty programme documentation can be found [here](https://duffel.com/docs/api/v1/accommodation-loyalty-programmes).

