### PR TITLE
Read more logo urls from updated api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -677,5 +677,7 @@ export interface StaysSearchResult {
 export interface StaysLoyaltyProgramme {
   reference: StaysLoyaltyProgrammeReference
   name: string
-  logo_url: string | null
+  logo_url: string
+  logo_url_svg: string
+  logo_url_png_small: string
 }

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -237,5 +237,9 @@ export const MOCK_LOYALTY_PROGRAMMES: StaysLoyaltyProgramme[] = [
     name: 'Duffel Hotel Group Rewards',
     logo_url:
       'https://assets.duffel.com/img/stays/loyalty-programmes/full-color-logo/duffel_hotel_group_rewards-square.svg',
+    logo_url_svg:
+      'https://assets.duffel.com/img/stays/loyalty-programmes/full-color-logo/duffel_hotel_group_rewards-square.svg',
+    logo_url_png_small:
+      'https://assets.duffel.com/img/stays/loyalty-programmes/transparent-logo/duffel_hotel_group_rewards.png',
   },
 ]


### PR DESCRIPTION
### What's here?

There are now new smaller png logos for different use case on loyalty programme. So we now read it from the API once it gets updated.