### PR TITLE
Remove deprecated logo_url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -677,7 +677,6 @@ export interface StaysSearchResult {
 export interface StaysLoyaltyProgramme {
   reference: StaysLoyaltyProgrammeReference
   name: string
-  logo_url: string
   logo_url_svg: string
   logo_url_png_small: string
 }

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -235,8 +235,6 @@ export const MOCK_LOYALTY_PROGRAMMES: StaysLoyaltyProgramme[] = [
   {
     reference: 'duffel_hotel_group_rewards',
     name: 'Duffel Hotel Group Rewards',
-    logo_url:
-      'https://assets.duffel.com/img/stays/loyalty-programmes/full-color-logo/duffel_hotel_group_rewards-square.svg',
     logo_url_svg:
       'https://assets.duffel.com/img/stays/loyalty-programmes/full-color-logo/duffel_hotel_group_rewards-square.svg',
     logo_url_png_small:


### PR DESCRIPTION
### What's here?

since logo_url is just a duplicate of logo_url_svg and no one is using it, we remove it from the SDK