### PR TITLE
fix: update depreciated type & fix nullable values

### DIFF
--- a/src/booking/Offers/OfferTypes.ts
+++ b/src/booking/Offers/OfferTypes.ts
@@ -11,6 +11,7 @@ import {
   PaginationMeta,
   DuffelPassengerType,
   OfferSliceConditions,
+  CreateOfferRequestPassengerFareType,
 } from '../../types'
 
 /**
@@ -22,7 +23,7 @@ export interface Offer {
    * The types of identity documents that may be provided for the passengers when creating an order based on this offer.
    * If this is `[]`, then you must not provide identity documents.
    */
-  allowed_passenger_identity_document_types: PassengerIdentityDocumentType[]
+  supported_passenger_identity_document_types: PassengerIdentityDocumentType[]
 
   /**
    * The services that can be booked along with the offer but are not included by default, for example an additional checked bag.
@@ -316,12 +317,18 @@ export interface OfferPassenger {
   /**
    * The age of the passenger on the departure_date of the final slice.
    */
-  age?: number
+  age: number | null
 
   /**
    * The type of the passenger.
    */
-  type?: DuffelPassengerType
+  type: DuffelPassengerType | null
+
+  /**
+   * The fare type of the passenger. If the passenger is aged less than 18, you
+   * should pass in age as well.
+   */
+  fare_type: CreateOfferRequestPassengerFareType | null
 
   /**
    * The passenger's family name. Only `space`, `-`, `'`, and letters from the `ASCII`, `Latin-1 Supplement` and `Latin
@@ -331,7 +338,7 @@ export interface OfferPassenger {
    *
    * This is only required if you're also including **Loyalty Programme Accounts**.
    */
-  family_name?: string
+  family_name: string | null
 
   /**
    * The passenger's given name. Only `space`, `-`, `'`, and letters from the `ASCII`, `Latin-1 Supplement` and `Latin
@@ -341,12 +348,12 @@ export interface OfferPassenger {
    *
    * This is only required if you're also including **Loyalty Programme Accounts**.
    */
-  given_name?: string
+  given_name: string | null
 
   /**
    * The **Loyalty Programme Accounts** for this passenger.
    */
-  loyalty_programme_accounts?: LoyaltyProgrammeAccount[]
+  loyalty_programme_accounts: LoyaltyProgrammeAccount[]
 
   /**
    * The identifier for the passenger, unique within this Offer Request and across all Offer Requests.

--- a/src/booking/Offers/mockOffer.ts
+++ b/src/booking/Offers/mockOffer.ts
@@ -170,6 +170,7 @@ export const mockOffer: Offer = {
   passengers: [
     {
       type: 'adult',
+      fare_type: 'contract_bulk',
       id: 'pas_00009hj8USM7Ncg31cBCL',
       age: 14,
       given_name: 'Carol',
@@ -244,7 +245,7 @@ export const mockOffer: Offer = {
       type: 'cancel_for_any_reason',
     },
   ],
-  allowed_passenger_identity_document_types: ['passport'],
+  supported_passenger_identity_document_types: ['passport'],
 }
 
 export const mockUpdatedOffer = {

--- a/src/booking/Offers/mockPartialOffer.ts
+++ b/src/booking/Offers/mockPartialOffer.ts
@@ -170,6 +170,7 @@ export const mockPartialOffer: Offer = {
   passengers: [
     {
       type: 'adult',
+      fare_type: 'contract_bulk',
       id: 'pas_00009hj8USM7Ncg31cBCL',
       age: 14,
       given_name: 'Carol',
@@ -244,7 +245,7 @@ export const mockPartialOffer: Offer = {
       type: 'cancel_for_any_reason',
     },
   ],
-  allowed_passenger_identity_document_types: ['passport'],
+  supported_passenger_identity_document_types: ['passport'],
 }
 
 export const mockUpdatedOffer = {

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -172,7 +172,7 @@ export interface OrderPassenger {
 
 export interface OrderPassengerIdentityDocument {
   /**
-   * The type of the identity document. This must be one of the allowed_passenger_identity_document_types on the offer.
+   * The type of the identity document. This must be one of the supported_passenger_identity_document_types on the offer.
    */
   type: PassengerIdentityDocumentType
 
@@ -194,7 +194,7 @@ export interface OrderPassengerIdentityDocument {
 
 export interface CreateOrderPassenger extends Omit<OrderPassenger, 'type'> {
   /**
-   * The passenger's identity documents. You may only provide one identity document per passenger. The identity document's type must be included in the offer's allowed_passenger_identity_document_types. If the offer's passenger_identity_documents_required is set to true, then an identity document must be provided.
+   * The passenger's identity documents. You may only provide one identity document per passenger. The identity document's type must be included in the offer's supported_passenger_identity_document_types. If the offer's passenger_identity_documents_required is set to true, then an identity document must be provided.
    */
   identity_documents?: OrderPassengerIdentityDocument[]
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -55,9 +55,13 @@ export type DuffelPassengerGender = 'm' | 'f'
 
 /**
  * The type of the identity document.
- * This must be one of the `allowed_passenger_identity_document_types` on the offer.
+ * This must be one of the `supported_passenger_identity_document_types` on the offer.
  */
-export type PassengerIdentityDocumentType = 'passport' | 'tax_id'
+export type PassengerIdentityDocumentType =
+  | 'passport'
+  | 'tax_id'
+  | 'known_traveler_number'
+  | 'passenger_redress_number'
 
 /**
  * The type of the origin or destination


### PR DESCRIPTION
The `allowed_passenger_identity_document_types` field was depreciated in v2 so this has been updated to its updated field `supported_passenger_identity_document_types` with all its possible values as per the schema.

Also, the schema for order says all the passenger values are nullable but still exist in the response so this has been updated.
Also `fare_type` was missing from this so I've added it in.