### PR TITLE
Read booking contacts from API response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -562,6 +562,16 @@ export interface StaysBooking {
   id: string
 
   /**
+   * The email of the lead guest of the booking
+   */
+  email: string
+
+  /**
+   * The phone number of the lead guest of the booking
+   */
+  phone_number: string
+
+  /**
    * The accommodation object for the booking
    */
   accommodation: StaysAccommodation

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -165,6 +165,8 @@ export const MOCK_SEARCH_RESULT: StaysSearchResult = {
 
 export const MOCK_BOOKING: StaysBooking = {
   accommodation: MOCK_ACCOMMODATION,
+  email: 'jean@example.com',
+  phone_number: '+4407242242424',
   status: 'confirmed',
   reference: 'dhg-4692ARxBI85qTkbDDEZMO8',
   id: 'bok_0000ARxBI85qTkbDDEZMO3',


### PR DESCRIPTION
### What's here?

We introduced a change to our responses, such that it should reflect the given email and phone number for the booking. This should streamline some important information for integrators much better.