### PR TITLE
Introduces component client keys

### DIFF
--- a/src/booking/Identity/ComponentClientKey/ComponentClientKeys.spec.ts
+++ b/src/booking/Identity/ComponentClientKey/ComponentClientKeys.spec.ts
@@ -1,0 +1,25 @@
+import nock from 'nock'
+import { Client } from '../../../Client'
+import { ComponentClientKeys } from './ComponentClientKeys'
+import { mockComponentClientKey } from './mockComponentClientKey'
+
+describe('component client keys', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  test('creates a component client key', async () => {
+    nock(/(.*)/)
+      .post(`/identity/component_client_keys/`)
+      .reply(200, { data: mockComponentClientKey })
+
+    const response = await new ComponentClientKeys(
+      new Client({ token: 'mockToken' }),
+    ).create()
+
+    const regex_to_match_jwt = new RegExp(
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.[a-zA-Z0-9_-]*.[a-zA-Z0-9_-]*',
+    )
+    expect(response.data.component_client_key).toMatch(regex_to_match_jwt)
+  })
+})

--- a/src/booking/Identity/ComponentClientKey/ComponentClientKeys.ts
+++ b/src/booking/Identity/ComponentClientKey/ComponentClientKeys.ts
@@ -1,0 +1,26 @@
+import { Resource } from '../../../Resource'
+import { type DuffelResponse } from '../../../types/ClientType'
+import { type ComponentClientKey } from './types'
+/**
+ * A component client key is a unique identifier that allows you to authenticate with the Duffel API.
+ */
+export class ComponentClientKeys extends Resource {
+  /**
+   * Endpoint path
+   */
+  path: string
+
+  constructor(args: any) {
+    super(args)
+    this.path = 'identity/component_client_keys/'
+  }
+
+  /**
+   * A component client key is a unique identifier that allows you to authenticate with the Duffel API.
+   * @param data A JSON object containing the data to create a new component client key
+   */
+  public create = async (
+    data: Record<string, string> = {},
+  ): Promise<DuffelResponse<ComponentClientKey>> =>
+    this.request({ method: 'POST', path: `${this.path}`, data })
+}

--- a/src/booking/Identity/ComponentClientKey/mockComponentClientKey.ts
+++ b/src/booking/Identity/ComponentClientKey/mockComponentClientKey.ts
@@ -1,0 +1,6 @@
+import { type ComponentClientKey } from './types'
+
+export const mockComponentClientKey: ComponentClientKey = {
+  component_client_key:
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiaWN1XzAwMDBBZ1ppdHBPblF0ZDNOUXhqd08iLCJvcmRlcl9pZCI6Im9yZF8wMDAwQUJkWm5nZ1NjdDdCb3JhVTFvIiwiaWF0IjoxNTE2MjM5MDIyfQ.GtJDKrfum7aLlNaXmUj-RtQIbx0-Opwjdid0fiJk6DE',
+}

--- a/src/booking/Identity/ComponentClientKey/types.ts
+++ b/src/booking/Identity/ComponentClientKey/types.ts
@@ -1,0 +1,6 @@
+export interface ComponentClientKey {
+  /**
+   * The client key used to authenticate Duffel UI components to our API.
+   */
+  component_client_key: string
+}


### PR DESCRIPTION
__what__

We are soon to make component client keys public in our API reference. To better support or merchants in using that endpoint, this PR adds component client key creation to our client.   