### PR TITLE
feat: allow 3ds session ID for payments on bookings

### DIFF
--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -13,7 +13,7 @@ export interface StaysBookingPayload {
   email: string
   phone_number: string
   accommodation_special_requests?: string
-  payment?: { card_id: string }
+  payment?: { card_id: string } | { three_d_secure_session_id: string }
 }
 
 export class Bookings extends Resource {


### PR DESCRIPTION
This adds ability to allow 3ds payments for bookings. 