### PR TITLE
ci(release): 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release 3.1.2

Attempting to do this manually since something seems to be broken with the automation (duffel-bot is not creating the PRs). Will look into that next.