### PR TITLE
fix: testing if squash merging is the problem

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Committing to the repository
 
-To be able to publish the correct version to NPM, we are currently following [Angular conventional commit message guidelines](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) which is based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). The previous commit message guideline allow us to trigger [semantic-release GitHub action](##client-ci).
+To be able to publish the correct version to NPM, we are currently following [Angular conventional commit message guidelines](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) which is based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). The previous commit message guideline allows us to trigger [semantic-release GitHub action](##client-ci).
 
 ### CommitLint to the rescue
 


### PR DESCRIPTION
My current theory about why automatic release has been failing recently is because we've defaulted to Squash commits, which alter the commit message, so it doesn't hit the right triggers. More discussion here: https://github.com/semantic-release/commit-analyzer/issues/177

This is basically a test commit where I'll try a normal merge and see if the release is triggered.