### PR TITLE
Expose brands to JS SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/Brands/Brands.spec.ts
+++ b/src/Stays/Brands/Brands.spec.ts
@@ -1,0 +1,26 @@
+import nock from 'nock'
+import { Duffel } from '../../index'
+import { MOCK_BRAND } from '../mocks'
+
+const duffel = new Duffel({ token: 'mockToken' })
+describe('Stays/Brands', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should get to /stays/brands when `list` is called', async () => {
+    const mockResponse = { data: [MOCK_BRAND] }
+
+    nock(/(.*)/).get('/stays/brands').reply(200, mockResponse)
+    const response = await duffel.stays.brands.list()
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should get to /stays/brands/{id} when `get` is called', async () => {
+    const mockResponse = { data: MOCK_BRAND }
+
+    nock(/(.*)/).get(`/stays/brands/${MOCK_BRAND.id}`).reply(200, mockResponse)
+    const response = await duffel.stays.brands.get(MOCK_BRAND.id)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+})

--- a/src/Stays/Brands/Brands.ts
+++ b/src/Stays/Brands/Brands.ts
@@ -1,0 +1,37 @@
+import { Client } from '../../Client'
+import { StaysAccommodationBrand } from '../StaysTypes'
+import { Resource } from '../../Resource'
+import { DuffelResponse } from '../../types'
+
+export class Brands extends Resource {
+  /**
+   * Endpoint path
+   */
+  path: string
+
+  constructor(client: Client) {
+    super(client)
+    this.path = 'stays/brands'
+  }
+
+  /**
+   * Get a brand
+   * @param {string} brandId - The ID of the brand
+   */
+  public get = async (
+    brandId: string,
+  ): Promise<DuffelResponse<StaysAccommodationBrand>> =>
+    this.request({
+      method: 'GET',
+      path: `${this.path}/${brandId}`,
+    })
+
+  /**
+   * List brands
+   */
+  public list = async (): Promise<DuffelResponse<StaysAccommodationBrand[]>> =>
+    this.request({
+      method: 'GET',
+      path: this.path,
+    })
+}

--- a/src/Stays/Brands/index.ts
+++ b/src/Stays/Brands/index.ts
@@ -1,0 +1,1 @@
+export * from './Brands'

--- a/src/Stays/Stays.ts
+++ b/src/Stays/Stays.ts
@@ -3,6 +3,7 @@ import { StaysSearchParams, StaysSearchResult } from './StaysTypes'
 import { Resource } from '../Resource'
 import { DuffelResponse } from '../types'
 import { Accommodation } from './Accommodation'
+import { Brands } from './Brands'
 import { LoyaltyProgrammes } from './LoyaltyProgrammes'
 import { Bookings } from './Bookings'
 import { Quotes } from './Quotes'
@@ -16,6 +17,7 @@ export class Stays extends Resource {
 
   public accommodation: Accommodation
   public loyaltyProgrammes: LoyaltyProgrammes
+  public brands: Brands
   public searchResults: SearchResults
   public quotes: Quotes
   public bookings: Bookings
@@ -25,6 +27,7 @@ export class Stays extends Resource {
     this.path = 'stays'
 
     this.accommodation = new Accommodation(client)
+    this.brands = new Brands(client)
     this.loyaltyProgrammes = new LoyaltyProgrammes(client)
     this.searchResults = new SearchResults(client)
     this.quotes = new Quotes(client)

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -301,6 +301,11 @@ export interface StaysLocation {
   geographic_coordinates: GeographicCoordinates | null
 }
 
+export interface StaysAccommodationBrand {
+  name: string
+  id: string
+}
+
 export interface StaysAccommodation {
   /**
    * Duffel ID for this accommodation. Useful for searching availability
@@ -316,6 +321,8 @@ export interface StaysAccommodation {
    * Information about the chain this accommodation belongs to
    */
   chain: StaysChain | null
+
+  brand: StaysAccommodationBrand | null
 
   /**
    * Check in and check out related information

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -1,6 +1,7 @@
 // eslint-disable spellcheck/spell-checker
 import {
   StaysAccommodation,
+  StaysAccommodationBrand,
   StaysAccommodationSuggestion,
   StaysBooking,
   StaysLoyaltyProgramme,
@@ -8,6 +9,11 @@ import {
   StaysSearchResult,
 } from './StaysTypes'
 import { StaysBookingPayload } from './Bookings/Bookings'
+
+export const MOCK_BRAND: StaysAccommodationBrand = {
+  id: 'bra_DQPneLbCejxRuxAqD7amaW',
+  name: 'The Ritz-Carlton',
+}
 
 export const MOCK_ACCOMMODATION: StaysAccommodation = {
   id: 'acc_0000AWr2VsUNIF1Vl91xg0',
@@ -143,8 +149,9 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
   key_collection: {
     instructions: 'Key is at the property. Collect from the lock box.',
   },
+  brand: MOCK_BRAND,
   chain: {
-    name: 'The Ritz-Carlton',
+    name: 'Marriott International',
   },
   supported_loyalty_programme: 'duffel_hotel_group_rewards',
 }


### PR DESCRIPTION
### What's here?

We are preparing to expose brands endpoints as types and calls via our SDK.

This also cleans up the mock accommodation to have an accurate representation of brand and chain from actual duffel data.

### References

- https://duffel.com/docs/api/v2/brands