### PR TITLE
feat: add pagination params support to list Stays Bookings

### DIFF
--- a/src/Stays/Bookings/Bookings.spec.ts
+++ b/src/Stays/Bookings/Bookings.spec.ts
@@ -42,6 +42,36 @@ describe('Stays/Bookings', () => {
     expect(response.data).toEqual(mockResponse.data)
   })
 
+  it('should get a page of bookings when `list` is called with pagination params', async () => {
+    const mockResponse = { data: [MOCK_BOOKING] }
+
+    nock(/(.*)/)
+      .get('/stays/bookings')
+      .query((queryObject) => {
+        expect(queryObject.limit).toEqual('1')
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.bookings.list({ limit: 1 })
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should get all bookings paginated', async () => {
+    nock(/(.*)/)
+      .get(`/stays/bookings`)
+      .reply(200, {
+        data: [MOCK_BOOKING],
+        meta: { limit: 1, before: null, after: null },
+      })
+
+    const response = duffel.stays.bookings.listWithGenerator()
+
+    for await (const page of response) {
+      expect(page.data.id).toBe(MOCK_BOOKING.id)
+    }
+  })
+
   it('should get to /stays/bookings/{id} when `get` is called', async () => {
     const mockResponse = { data: MOCK_BOOKING }
 

--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -1,7 +1,7 @@
 import { Client } from '../../Client'
 import { StaysBooking } from '../StaysTypes'
 import { Resource } from '../../Resource'
-import { DuffelResponse } from '../../types'
+import { DuffelResponse, PaginationMeta } from '../../types'
 
 export interface StaysBookingPayload {
   quote_id: string
@@ -54,12 +54,23 @@ export class Bookings extends Resource {
 
   /**
    * List bookings
+   * @param {Object} [options] - Pagination options (optional: limit, after, before)
+   * @link https://duffel.com/docs/api/bookings/list-bookings
    */
-  public list = async (): Promise<DuffelResponse<StaysBooking[]>> =>
-    this.request({
-      method: 'GET',
-      path: this.path,
-    })
+  public list = async (
+    options?: PaginationMeta,
+  ): Promise<DuffelResponse<StaysBooking[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
+
+  /**
+   * Retrieves a generator of all bookings. The results may be returned in any order.
+   * @link https://duffel.com/docs/api/bookings/list-bookings
+   */
+  public listWithGenerator = (): AsyncGenerator<
+    DuffelResponse<StaysBooking>,
+    void,
+    unknown
+  > => this.paginatedRequest({ path: this.path })
 
   /**
    * Cancel a booking


### PR DESCRIPTION
The https://duffel.com/docs/api/bookings/list-bookings now supports pagination params.

So it mimics add pagination parameters like it does for Flights orders.