### PR TITLE
Adds missing type to seat map element

### DIFF
--- a/src/booking/SeatMaps/SeatMapTypes.ts
+++ b/src/booking/SeatMaps/SeatMapTypes.ts
@@ -91,7 +91,7 @@ export interface SeatMapCabinRowSectionElementSeat {
   /**
    * The type of this element.
    */
-  type: 'seat'
+  type: 'seat' | 'restricted_seat_general'
 
   /**
    * The designator used to uniquely identify the seat, usually made up of a row number and a column letter


### PR DESCRIPTION
We received a [report that seat maps looked broken](https://duffel.atlassian.net/browse/FR-8249?focusedCommentId=43085). That's because the component encountered an element type it was not equipped to handle, this PR adds the element type to our typescript definition, so we can use it to update the component.  