### PR TITLE
Fix: `StaysAddress` `region` type

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -279,7 +279,7 @@ export interface StaysAddress {
   /**
    * The stay's region or state
    */
-  region: string
+  region?: string
 }
 
 export interface GeographicCoordinates {


### PR DESCRIPTION
The `region` field on `StaysAddress` is marked as a `string`, but at run time we have received `null`.
I am unsure if the fix should instead be ensuring `region` is never null, but if wanted, this PR updates the type to a nullable string.