### PR TITLE
feat: allow metadata in booking creation payload

### DIFF
--- a/src/Stays/Bookings/Bookings.spec.ts
+++ b/src/Stays/Bookings/Bookings.spec.ts
@@ -22,6 +22,9 @@ describe('Stays/Bookings', () => {
       ],
       email: 'a@example.com',
       phone_number: '+447700900000',
+      metadata: {
+        customer_reference_number: 'ABXYZZ53Z',
+      },
     }
 
     nock(/(.*)/)

--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -14,6 +14,7 @@ export interface StaysBookingPayload {
   phone_number: string
   accommodation_special_requests?: string
   payment?: { card_id: string } | { three_d_secure_session_id: string }
+  metadata?: StaysBooking['metadata']
 }
 
 export class Bookings extends Resource {


### PR DESCRIPTION
### What's here?

This allows metadata to be passed as payload when creating stays bookings via the js sdk