### PR TITLE
fix: add missing types

### DIFF
--- a/src/booking/Offers/OfferTypes.ts
+++ b/src/booking/Offers/OfferTypes.ts
@@ -452,6 +452,11 @@ export interface OfferSlice {
    *    - `"5"`: deluxe seating, additional legroom and reclines to lie flat position. Situated in business class or higher.
    */
   ngs_shelf: number | null
+
+  /**
+   * A hash uniquely identifying this slice. This value could be use to group together identical slices from different offers.
+   */
+  comparison_key: string
 }
 
 export interface OfferSliceSegment {

--- a/src/booking/Offers/mockOffer.ts
+++ b/src/booking/Offers/mockOffer.ts
@@ -9,6 +9,7 @@ export const mockOffer: Offer = {
   tax_amount: '40.80',
   slices: [
     {
+      comparison_key: 'BmlZDw==',
       ngs_shelf: 1,
       segments: [
         {

--- a/src/booking/Offers/mockPartialOffer.ts
+++ b/src/booking/Offers/mockPartialOffer.ts
@@ -9,6 +9,7 @@ export const mockPartialOffer: Offer = {
   tax_amount: '40.80',
   slices: [
     {
+      comparison_key: 'BmlZDw==',
       ngs_shelf: 1,
       segments: [
         {

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -15,6 +15,7 @@ import {
   PaymentType,
   Place,
   PlaceType,
+  OrderCancellation,
 } from '../../types'
 
 /**
@@ -594,6 +595,11 @@ export interface Order {
    * @example "2020-04-11T15:48:11Z"
    */
   synced_at: string
+
+  /**
+   * The confirmed cancellation associated with this Order (if this Order has been cancelled)
+   */
+  cancellation?: OrderCancellation | null
 }
 
 export type OrderAvailableAction = 'cancel' | 'change' | 'update'

--- a/src/booking/Orders/mockOrders.ts
+++ b/src/booking/Orders/mockOrders.ts
@@ -52,6 +52,7 @@ export const mockOrder: Order = {
   total_amount: '90.80',
   tax_currency: 'GBP',
   tax_amount: '30.20',
+  cancellation: null,
   slices: [
     {
       segments: [


### PR DESCRIPTION
We were missing the [slice comparison key](https://duffel.com/docs/api/v2/offers#offers-schema-slices-slices-comparison-key) and [order cancellations](https://duffel.com/docs/api/v2/orders#orders-schema-cancellation).