### PR TITLE
Adds get quote operation for stays

### DIFF
--- a/src/Stays/Quotes/Quotes.spec.ts
+++ b/src/Stays/Quotes/Quotes.spec.ts
@@ -8,6 +8,19 @@ describe('Stays/Quotes', () => {
     nock.cleanAll()
   })
 
+  it('should get /stays/quote/:id when `get` is called', async () => {
+    const quoteId = 'quo_123'
+    const mockResponse = { data: MOCK_QUOTE }
+
+    nock(/(.*)/)
+      .get(`/stays/quotes/${quoteId}`, (_) => {
+        return true
+      })
+      .reply(200, mockResponse)
+    const response = await duffel.stays.quotes.get(quoteId)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
   it('should post to /stays/quotes when `create` is called', async () => {
     const rateId = 'rat_123'
     const mockResponse = { data: MOCK_QUOTE }

--- a/src/Stays/Quotes/Quotes.ts
+++ b/src/Stays/Quotes/Quotes.ts
@@ -16,6 +16,16 @@ export class Quotes extends Resource {
 
   /**
    * Create a quote for the selected rate
+   * @param {string} quoteId - The ID of the rate to create a quote for
+   */
+  public get = async (quoteId: string): Promise<DuffelResponse<StaysQuote>> =>
+    this.request({
+      method: 'GET',
+      path: `${this.path}/${quoteId}`,
+    })
+
+  /**
+   * Create a quote for the selected rate
    * @param {string} rateId - The ID of the rate to create a quote for
    */
   public create = async (rateId: string): Promise<DuffelResponse<StaysQuote>> =>


### PR DESCRIPTION
The GET quote endpoint is missing from our client library. This PR corrects that. 