### PR TITLE
feat: add public pricing properties to SearchResult

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -684,6 +684,8 @@ export interface StaysSearchResult {
   guests: Array<Guest>
   cheapest_rate_total_amount: string
   cheapest_rate_currency: string
+  cheapest_rate_public_amount: string | null
+  cheapest_rate_public_currency: string
 }
 
 export interface StaysLoyaltyProgramme {

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -165,6 +165,8 @@ export const MOCK_SEARCH_RESULT: StaysSearchResult = {
   guests: [{ type: 'adult' }, { type: 'adult' }],
   cheapest_rate_total_amount: '799.00',
   cheapest_rate_currency: 'GBP',
+  cheapest_rate_public_amount: null,
+  cheapest_rate_public_currency: 'GBP',
 }
 
 export const MOCK_BOOKING: StaysBooking = {


### PR DESCRIPTION
### Whats here?

- Adds two preview properties from SearchResult
  - https://duffel.com/docs/api/v2/search-result/schema#search-result-schema-cheapest-rate-public-amount
  - https://duffel.com/docs/api/v2/search-result/schema#search-result-schema-cheapest-rate-public-currency
- These open up the potential for strikethrough pricing in user interfaces using this SDK (Note that preview fields and their behaviour may change without notice)