### PR TITLE
Exposes `hasService` helper

### DIFF
--- a/src/functions/hasAvailableSeatService.spec.ts
+++ b/src/functions/hasAvailableSeatService.spec.ts
@@ -1,0 +1,66 @@
+import { SeatMap } from 'types'
+import { hasAvailableSeatService } from './hasAvailableSeatService'
+
+describe('hasAvailableSeatService', () => {
+  it('should return false when seatMaps is undefined', () => {
+    expect(hasAvailableSeatService()).toBe(false)
+  })
+
+  it('should return false when seatMaps is an empty array', () => {
+    expect(hasAvailableSeatService([])).toBe(false)
+  })
+
+  it('should return false when seatMaps do not contain any seat with available services', () => {
+    const seatMaps: SeatMap[] = [
+      {
+        cabins: [
+          {
+            rows: [
+              {
+                sections: [
+                  {
+                    elements: [
+                      {
+                        type: 'seat',
+                        available_services: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as any,
+    ]
+    const result = hasAvailableSeatService(seatMaps)
+    expect(result).toBe(false)
+  })
+
+  it('should return true when seatMaps contain a seat with available services', () => {
+    const seatMaps: SeatMap[] = [
+      {
+        cabins: [
+          {
+            rows: [
+              {
+                sections: [
+                  {
+                    elements: [
+                      {
+                        type: 'seat',
+                        available_services: ['service1', 'service2'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as any,
+    ]
+    const result = hasAvailableSeatService(seatMaps)
+    expect(result).toBe(true)
+  })
+})

--- a/src/functions/hasAvailableSeatService.ts
+++ b/src/functions/hasAvailableSeatService.ts
@@ -1,0 +1,24 @@
+import { SeatMap } from 'types'
+
+export function hasAvailableSeatService(seatMaps?: SeatMap[]): boolean {
+  if (!Array.isArray(seatMaps) || seatMaps.length === 0) return false
+
+  for (const seatMap of seatMaps) {
+    for (const cabin of seatMap.cabins) {
+      for (const rows of cabin.rows) {
+        for (const section of rows.sections) {
+          for (const element of section.elements) {
+            if (
+              element.type === 'seat' &&
+              element.available_services.length > 0
+            ) {
+              return true
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return false
+}

--- a/src/functions/hasService.spec.ts
+++ b/src/functions/hasService.spec.ts
@@ -1,0 +1,67 @@
+import { SeatMap } from 'types'
+import { hasService } from './hasService'
+
+describe('hasService', () => {
+  // A basic offer with no available services
+  const baseOffer = {
+    available_services: [],
+  } as any
+
+  it('should return false when no seat maps passed and no available services on offer (no services available at all)', () => {
+    // No seat maps provided and the offer has no available services
+    expect(hasService(baseOffer)).toBe(false)
+  })
+
+  it('should return false when seat maps is an empty array and no available services on offer', () => {
+    // Seat maps provided as empty array and no service on the offer
+    expect(hasService(baseOffer, [])).toBe(false)
+  })
+
+  it('should return true when no seat maps passed but offer has a service available', () => {
+    // Offer has a service (e.g. a baggage service) with maximum_quantity > 0
+    // and seat maps are not provided
+
+    const offerWithService = {
+      available_services: [{ maximum_quantity: 1, type: 'baggage' }],
+    } as any
+
+    expect(hasService(offerWithService)).toBe(true)
+  })
+
+  it('should return true when only seats available in seat maps', () => {
+    // Offer has no available services, but seat maps include a seat with available services
+    const seatMaps: SeatMap[] = [
+      {
+        cabins: [
+          {
+            rows: [
+              {
+                sections: [
+                  {
+                    elements: [
+                      {
+                        type: 'seat',
+                        available_services: ['service1', 'service2'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as any
+
+    expect(hasService(baseOffer, seatMaps)).toBe(true)
+  })
+  it('should return true when only baggages available in offer', () => {
+    // Offer has an available baggage service and seat maps are empty
+    const offerWithBaggage = {
+      available_services: [{ maximum_quantity: 1, type: 'baggage' }],
+    } as any
+
+    expect(hasService(offerWithBaggage, [])).toBe(true)
+    expect(hasService(offerWithBaggage, undefined)).toBe(true)
+  })
+})

--- a/src/functions/hasService.ts
+++ b/src/functions/hasService.ts
@@ -1,0 +1,11 @@
+import { Offer, SeatMap } from 'types'
+import { hasAvailableSeatService } from './hasAvailableSeatService'
+
+export function hasService(offer: Offer, seatMaps?: SeatMap[]) {
+  const offerHasService =
+    offer &&
+    Array.isArray(offer.available_services) &&
+    offer.available_services.some((service) => service.maximum_quantity > 0)
+
+  return offerHasService || hasAvailableSeatService(seatMaps)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,3 +102,7 @@ export class Duffel {
 }
 
 export const DuffelError = _DuffelError
+
+// Exports helper functions:
+export * from './functions/hasService'
+export * from './functions/hasAvailableSeatService'


### PR DESCRIPTION
__what__

Adds new functions to help merchants determine if services are present on an offer or seat map.