### PR TITLE
[STAY-2807] feat: add stays reviews endpoint

### DIFF
--- a/src/Stays/Accommodation/Accommodation.spec.ts
+++ b/src/Stays/Accommodation/Accommodation.spec.ts
@@ -1,6 +1,10 @@
 import nock from 'nock'
 import { Duffel } from '../../index'
-import { MOCK_ACCOMMODATION_SUGGESTION, MOCK_ACCOMMODATION } from '../mocks'
+import {
+  MOCK_ACCOMMODATION_SUGGESTION,
+  MOCK_ACCOMMODATION,
+  MOCK_REVIEW_RESPONSE,
+} from '../mocks'
 
 const duffel = new Duffel({ token: 'mockToken' })
 describe('Stays/Accommodation', () => {
@@ -49,7 +53,7 @@ describe('Stays/Accommodation', () => {
     expect(response.data).toEqual(mockResponse.data)
   })
 
-  it('should send GET to /stays/{id} when `get` is called', async () => {
+  it('should send GET to /stays/accommodation/{id} when `get` is called', async () => {
     const id = MOCK_ACCOMMODATION.id
     const mockResponse = { data: MOCK_ACCOMMODATION }
 
@@ -60,6 +64,37 @@ describe('Stays/Accommodation', () => {
       .reply(200, mockResponse)
 
     const response = await duffel.stays.accommodation.get(id)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should send GET to /stays/accommodation/{id}/reviews when `get` is called', async () => {
+    const id = MOCK_ACCOMMODATION.id
+    const mockResponse = { data: MOCK_REVIEW_RESPONSE }
+
+    nock(/(.*)/)
+      .get(`/stays/accommodation/${id}/reviews`, () => {
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.accommodation.reviews(id)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should send GET to /stays/accommodation/{id}/reviews with pagination options when `get` is called', async () => {
+    const id = MOCK_ACCOMMODATION.id
+    const mockResponse = { data: MOCK_REVIEW_RESPONSE }
+
+    nock(/(.*)/)
+      .get(`/stays/accommodation/${id}/reviews?limit=1&after=EXAMPLE`, () => {
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.accommodation.reviews(id, {
+      limit: 1,
+      after: 'EXAMPLE',
+    })
     expect(response.data).toEqual(mockResponse.data)
   })
 

--- a/src/Stays/Accommodation/Accommodation.ts
+++ b/src/Stays/Accommodation/Accommodation.ts
@@ -4,9 +4,10 @@ import {
   ListAccommodationParams,
   StaysAccommodationSuggestion,
   StaysAccommodation,
+  StaysAccommodationReviewResponse,
 } from '../StaysTypes'
 import { Resource } from '../../Resource'
-import { DuffelResponse } from '../../types'
+import { DuffelResponse, PaginationMeta } from '../../types'
 
 export class Accommodation extends Resource {
   /**
@@ -34,6 +35,16 @@ export class Accommodation extends Resource {
         query: query,
         location: location,
       },
+    })
+
+  public reviews = async (
+    id: StaysAccommodation['id'],
+    options?: PaginationMeta,
+  ): Promise<DuffelResponse<StaysAccommodationReviewResponse>> =>
+    this.request({
+      method: 'GET',
+      path: `${this.path}/${id}/reviews`,
+      params: options,
     })
 
   /**

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -694,3 +694,14 @@ export interface StaysLoyaltyProgramme {
   logo_url_svg: string
   logo_url_png_small: string
 }
+
+export interface StaysAccommodationReview {
+  created_at: string
+  reviewer_name: string
+  score: number
+  text: string
+}
+
+export interface StaysAccommodationReviewResponse {
+  reviews: Array<StaysAccommodationReview>
+}

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -2,6 +2,7 @@
 import {
   StaysAccommodation,
   StaysAccommodationBrand,
+  StaysAccommodationReviewResponse,
   StaysAccommodationSuggestion,
   StaysBooking,
   StaysLoyaltyProgramme,
@@ -156,6 +157,34 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
   supported_loyalty_programme: 'duffel_hotel_group_rewards',
 }
 
+export const MOCK_REVIEW_RESPONSE: StaysAccommodationReviewResponse = {
+  reviews: [
+    {
+      reviewer_name: 'Alice Johnson',
+      score: 5.1,
+      text: 'Amazing stay! The staff was incredibly friendly and the rooms were spotless. Highly recommend!',
+      created_at: '2023-03-01',
+    },
+    {
+      reviewer_name: 'Bob Smith',
+      score: 4.8,
+      text: 'Great location and comfortable rooms. The gym could use some more equipment though.',
+      created_at: '2023-02-15',
+    },
+    {
+      reviewer_name: 'Catherine Lee',
+      score: 3.0,
+      text: 'The hotel was decent, but the Wi-Fi was unreliable and the parking was expensive.',
+      created_at: '2023-01-20',
+    },
+    {
+      reviewer_name: 'David Brown',
+      score: 5.2,
+      text: 'Absolutely loved it! The food was fantastic and the view from the room was breathtaking.',
+      created_at: '2023-03-10',
+    },
+  ],
+}
 export const MOCK_SEARCH_RESULT: StaysSearchResult = {
   accommodation: MOCK_ACCOMMODATION,
   id: 'sta_something',


### PR DESCRIPTION
Adds the [accommodation reviews](https://duffel.com/docs/api/v2/accommodation-reviews) endpoint to the SDK.