### PR TITLE
Removes check for auto merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,3 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash


### PR DESCRIPTION
We don't want to enable that for this workflow. It breaks the release pipeline otherwise:

<img width="1527" alt="Screenshot 2025-05-27 at 16 28 31" src="https://github.com/user-attachments/assets/c8d988dd-0aca-432a-a767-bd8845b889ea" />

 