### PR TITLE
fix: updates order change broken types

### DIFF
--- a/src/booking/OrderChangeOffers/OrderChangeOfferTypes.ts
+++ b/src/booking/OrderChangeOffers/OrderChangeOfferTypes.ts
@@ -1,5 +1,8 @@
-import { OfferSliceSegment } from '../Offers/OfferTypes'
-import { PlaceType, Place } from '../../types'
+import {
+  OfferSliceSegment,
+  OfferSliceSegmentPassengerBaggage,
+} from '../Offers/OfferTypes'
+import { PlaceType, Place, CabinClass } from '../../types'
 
 /**
  * @link https://duffel.com/docs/api/order-change-offers/schema
@@ -137,5 +140,32 @@ export interface OrderChangeOfferSlice {
   /**
    * The segments - that is, specific flights - that the airline is offering to get the passengers from the `origin` to the `destination`
    */
-  segments: Array<Omit<OfferSliceSegment, 'passengers'>>
+  segments: Array<
+    Pick<
+      OfferSliceSegment,
+      | 'aircraft'
+      | 'arriving_at'
+      | 'departing_at'
+      | 'destination'
+      | 'destination_terminal'
+      | 'distance'
+      | 'duration'
+      | 'id'
+      | 'marketing_carrier'
+      | 'marketing_carrier_flight_number'
+      | 'operating_carrier'
+      | 'operating_carrier_flight_number'
+      | 'origin'
+      | 'origin_terminal'
+    > & {
+      /** Additional segment-specific information about the passengers included in the offer (e.g. their baggage allowance and the cabin class they will be travelling in) */
+      passengers: Array<{
+        baggages: OfferSliceSegmentPassengerBaggage[]
+        cabin_class: CabinClass | null
+        cabin_class_marketing_name: string | null
+        passenger_id: string
+        seat: { designator: string; disclosure: string; name: string }
+      }>
+    }
+  >
 }

--- a/src/booking/OrderChangeOffers/mockOrderChangeOffer.ts
+++ b/src/booking/OrderChangeOffers/mockOrderChangeOffer.ts
@@ -7,7 +7,7 @@ export const mockOrderChangeOffer: OrderChangeOffer = {
       {
         segments: [
           {
-            stops: [],
+            passengers: [],
             origin_terminal: 'B',
             origin: {
               time_zone: 'Europe/London',
@@ -136,7 +136,7 @@ export const mockOrderChangeOffer: OrderChangeOffer = {
       {
         segments: [
           {
-            stops: [],
+            passengers: [],
             origin_terminal: 'B',
             origin: {
               time_zone: 'Europe/London',

--- a/src/booking/OrderChangeRequests/OrderChangeRequestsTypes.ts
+++ b/src/booking/OrderChangeRequests/OrderChangeRequestsTypes.ts
@@ -4,7 +4,7 @@ import { OrderChangeOfferSlices } from '../OrderChangeOffers/OrderChangeOfferTyp
 export interface OrderChangeSliceResponse {
   remove: {
     slice_id: string
-  }
+  }[]
   add: {
     /**
      * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date on which the passengers want to depart
@@ -21,8 +21,8 @@ export interface OrderChangeSliceResponse {
     /**
      * The cabin that the passengers want to travel in
      */
-    cabin_class: CabinClass
-  }
+    cabin_class: CabinClass | null
+  }[]
 }
 
 export interface OrderChangeOffers {
@@ -122,7 +122,7 @@ export interface CreateOrderChangeRequest {
       /**
        * The cabin that the passengers want to travel in
        */
-      cabin_class: CabinClass
+      cabin_class?: CabinClass | null
       /**
        * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date on which the passengers want to depart
        */

--- a/src/booking/OrderChangeRequests/OrderRequestChanges.spec.ts
+++ b/src/booking/OrderChangeRequests/OrderRequestChanges.spec.ts
@@ -31,10 +31,10 @@ describe('OrderChangeRequests', () => {
     const response = await new OrderChangeRequests(
       new Client({ token: 'mockToken' }),
     ).create(mockCreateChangeRequest)
-    expect(response.data?.slices.remove.slice_id).toBe(
+    expect(response.data?.slices.remove[0].slice_id).toBe(
       mockCreateChangeRequest.slices.remove[0].slice_id,
     )
-    expect(response.data?.slices.add.destination.iata_code).toBe(
+    expect(response.data?.slices.add[0].destination.iata_code).toBe(
       mockCreateChangeRequest.slices.add[0].destination,
     )
   })

--- a/src/booking/OrderChangeRequests/mockOrderChangeRequests.ts
+++ b/src/booking/OrderChangeRequests/mockOrderChangeRequests.ts
@@ -5,53 +5,57 @@ import {
 
 export const mockOrderChangeRequest: OrderChangeRequestResponse = {
   slices: {
-    remove: {
-      slice_id: 'sli_00009htYpSCXrwaB9Dn123',
-    },
-    add: {
-      origin: {
-        type: 'airport',
-        time_zone: 'Europe/London',
-        name: 'Heathrow',
-        longitude: -141.951519,
-        latitude: 64.068865,
-        id: 'arp_lhr_gb',
-        icao_code: 'EGLL',
-        iata_country_code: 'GB',
-        iata_code: 'LHR',
-        iata_city_code: 'LON',
-        city_name: 'London',
-        city: {
-          name: 'London',
-          id: 'cit_lon_gb',
-          iata_country_code: 'GB',
-          iata_code: 'LON',
-          type: 'city',
-        },
+    remove: [
+      {
+        slice_id: 'sli_00009htYpSCXrwaB9Dn123',
       },
-      destination: {
-        type: 'airport',
-        time_zone: 'Europe/London',
-        name: 'Heathrow',
-        longitude: -141.951519,
-        latitude: 64.068865,
-        id: 'arp_lhr_gb',
-        icao_code: 'EGLL',
-        iata_country_code: 'GB',
-        iata_code: 'LHR',
-        iata_city_code: 'LON',
-        city_name: 'London',
-        city: {
-          name: 'London',
-          id: 'cit_lon_gb',
+    ],
+    add: [
+      {
+        origin: {
+          type: 'airport',
+          time_zone: 'Europe/London',
+          name: 'Heathrow',
+          longitude: -141.951519,
+          latitude: 64.068865,
+          id: 'arp_lhr_gb',
+          icao_code: 'EGLL',
           iata_country_code: 'GB',
-          iata_code: 'LON',
-          type: 'city',
+          iata_code: 'LHR',
+          iata_city_code: 'LON',
+          city_name: 'London',
+          city: {
+            name: 'London',
+            id: 'cit_lon_gb',
+            iata_country_code: 'GB',
+            iata_code: 'LON',
+            type: 'city',
+          },
         },
+        destination: {
+          type: 'airport',
+          time_zone: 'Europe/London',
+          name: 'Heathrow',
+          longitude: -141.951519,
+          latitude: 64.068865,
+          id: 'arp_lhr_gb',
+          icao_code: 'EGLL',
+          iata_country_code: 'GB',
+          iata_code: 'LHR',
+          iata_city_code: 'LON',
+          city_name: 'London',
+          city: {
+            name: 'London',
+            id: 'cit_lon_gb',
+            iata_country_code: 'GB',
+            iata_code: 'LON',
+            type: 'city',
+          },
+        },
+        departure_date: '2020-04-24',
+        cabin_class: 'economy',
       },
-      departure_date: '2020-04-24',
-      cabin_class: 'economy',
-    },
+    ],
   },
   order_id: 'ord_0000A3bQ8FJIQoEfuC07n6',
   order_change_offers: [
@@ -62,7 +66,7 @@ export const mockOrderChangeRequest: OrderChangeRequestResponse = {
           {
             segments: [
               {
-                stops: [],
+                passengers: [],
                 origin_terminal: 'B',
                 origin: {
                   time_zone: 'Europe/London',
@@ -191,8 +195,8 @@ export const mockOrderChangeRequest: OrderChangeRequestResponse = {
           {
             segments: [
               {
+                passengers: [],
                 origin_terminal: 'B',
-                stops: [],
                 origin: {
                   time_zone: 'Europe/London',
                   name: 'Heathrow',
@@ -338,50 +342,52 @@ export const mockOrderChangeRequestAltered: OrderChangeRequestResponse = {
   ...mockOrderChangeRequest,
   slices: {
     ...mockOrderChangeRequest.slices,
-    add: {
-      origin: {
-        type: 'airport',
-        time_zone: 'Europe/London',
-        name: 'Heathrow',
-        longitude: -141.951519,
-        latitude: 64.068865,
-        id: 'arp_lhr_gb',
-        icao_code: 'EGLL',
-        iata_country_code: 'GB',
-        iata_code: 'LHR',
-        iata_city_code: 'LON',
-        city_name: 'London',
-        city: {
-          name: 'London',
-          id: 'cit_lon_gb',
+    add: [
+      {
+        origin: {
+          type: 'airport',
+          time_zone: 'Europe/London',
+          name: 'Heathrow',
+          longitude: -141.951519,
+          latitude: 64.068865,
+          id: 'arp_lhr_gb',
+          icao_code: 'EGLL',
           iata_country_code: 'GB',
-          iata_code: 'LON',
-          type: 'city',
+          iata_code: 'LHR',
+          iata_city_code: 'LON',
+          city_name: 'London',
+          city: {
+            name: 'London',
+            id: 'cit_lon_gb',
+            iata_country_code: 'GB',
+            iata_code: 'LON',
+            type: 'city',
+          },
         },
-      },
-      destination: {
-        type: 'airport',
-        time_zone: 'America/New_York',
-        name: 'John F. Kennedy International Airport',
-        longitude: -73.778519,
-        latitude: 40.640556,
-        id: 'arp_jfk_us',
-        icao_code: 'KJFK',
-        iata_country_code: 'US',
-        iata_code: 'JFK',
-        iata_city_code: 'NYC',
-        city_name: 'New York',
-        city: {
-          type: 'city',
-          name: 'New York',
-          id: 'cit_nyc_us',
+        destination: {
+          type: 'airport',
+          time_zone: 'America/New_York',
+          name: 'John F. Kennedy International Airport',
+          longitude: -73.778519,
+          latitude: 40.640556,
+          id: 'arp_jfk_us',
+          icao_code: 'KJFK',
           iata_country_code: 'US',
-          iata_code: 'NYC',
+          iata_code: 'JFK',
+          iata_city_code: 'NYC',
+          city_name: 'New York',
+          city: {
+            type: 'city',
+            name: 'New York',
+            id: 'cit_nyc_us',
+            iata_country_code: 'US',
+            iata_code: 'NYC',
+          },
         },
+        departure_date: '2020-04-24',
+        cabin_class: 'economy',
       },
-      departure_date: '2020-04-24',
-      cabin_class: 'economy',
-    },
+    ],
   },
 }
 
@@ -390,7 +396,7 @@ export const mockCreateChangeRequest: CreateOrderChangeRequest = {
   slices: {
     remove: [
       {
-        slice_id: mockOrderChangeRequest.slices.remove.slice_id,
+        slice_id: mockOrderChangeRequest.slices.remove[0].slice_id,
       },
     ],
     add: [

--- a/src/booking/OrderChanges/mockOrderChanges.ts
+++ b/src/booking/OrderChanges/mockOrderChanges.ts
@@ -6,7 +6,7 @@ export const mockOrderChange: OrderChange = {
       {
         segments: [
           {
-            stops: [],
+            passengers: [],
             origin_terminal: 'B',
             origin: {
               time_zone: 'Europe/London',
@@ -135,7 +135,7 @@ export const mockOrderChange: OrderChange = {
       {
         segments: [
           {
-            stops: [],
+            passengers: [],
             origin_terminal: 'B',
             origin: {
               time_zone: 'Europe/London',


### PR DESCRIPTION
__what's fixed here__

- on the payload to create request, slices cabin_class is defined as nullable but in the typings it's required.

-  GET order change request: the response of the slices is coming as an array of remove and add, but in the types, remove and add are marked as a single object.

- Add/Remove slice segments there's no stop defined but it is marked as a required field in the types.