### PR TITLE
feat: add new fields to Stays types [STAY-3590]

### DIFF
--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -396,6 +396,13 @@ export interface StaysAccommodation {
   rating: number | null
 
   /**
+   * The number of reviews that contributed to the aggregated review score
+
+   * Example: 336
+   */
+  review_count: number | null
+
+  /**
    * A review score of this accommodation, aggregated from guest reviews. If available, the value is a score from the 1.0-10.0 range. This value is consolidated by Duffel based on user review data from multiple sources.
    */
   review_score: number | null
@@ -526,6 +533,22 @@ export interface StaysQuote {
    * Example: "GBP"
    */
   due_at_accommodation_currency: string
+
+  /**
+   * The portion of total_amount that is payable before check in as deposit for the stay.
+   * It may be null if the quote is for a deposit rate but we couldn't get full deposit information —
+   * in that case, deposit details are expected to be specified in the rate conditions.
+   *
+   * Example: "159.80"
+   */
+  deposit_amount: string | null
+
+  /**
+   * The currency of the tax_amount, as an ISO 4217 currency code.
+   *
+   * Example: "GBP"
+   */
+  deposit_currency: string
 
   /**
    * The loyalty programme that this quote supports.
@@ -686,8 +709,12 @@ export interface StaysSearchResult {
   guests: Array<Guest>
   cheapest_rate_total_amount: string
   cheapest_rate_currency: string
+  cheapest_rate_base_amount: string | null
+  cheapest_rate_base_currency: string | null
   cheapest_rate_public_amount: string | null
   cheapest_rate_public_currency: string
+  cheapest_rate_due_at_accommodation_amount: string | null
+  cheapest_rate_due_at_accommodation_currency: string | null
 }
 
 export interface StaysLoyaltyProgramme {

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -33,6 +33,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
   ],
   rating: 4,
   review_score: 8.8,
+  review_count: 336,
   rooms: [
     {
       rates: [
@@ -196,6 +197,10 @@ export const MOCK_SEARCH_RESULT: StaysSearchResult = {
   cheapest_rate_currency: 'GBP',
   cheapest_rate_public_amount: null,
   cheapest_rate_public_currency: 'GBP',
+  cheapest_rate_base_amount: '665.83',
+  cheapest_rate_base_currency: 'GBP',
+  cheapest_rate_due_at_accommodation_amount: '39.95',
+  cheapest_rate_due_at_accommodation_currency: 'GBP',
 }
 
 export const MOCK_BOOKING: StaysBooking = {
@@ -255,6 +260,8 @@ export const MOCK_QUOTE: StaysQuote = {
   fee_currency: 'USD',
   tax_amount: null,
   tax_currency: 'USD',
+  deposit_amount: '0.00',
+  deposit_currency: 'USD',
   due_at_accommodation_amount: null,
   due_at_accommodation_currency: 'USD',
   supported_loyalty_programme: 'duffel_hotel_group_rewards',


### PR DESCRIPTION
Adds the following new fields to the Stays types based on recent releases.

- review count on Accommodation type
- deposit amount and currency on Quote type
- cheapest rate base and due_at_accommodation details on SearchResult type