### PR TITLE
feat: updates client to surface user_id query param

### DIFF
--- a/src/Stays/Bookings/Bookings.ts
+++ b/src/Stays/Bookings/Bookings.ts
@@ -1,5 +1,5 @@
 import { Client } from '../../Client'
-import { StaysBooking } from '../StaysTypes'
+import { ListParamsBookings, StaysBooking } from '../StaysTypes'
 import { Resource } from '../../Resource'
 import { DuffelResponse, PaginationMeta } from '../../types'
 
@@ -70,7 +70,7 @@ export class Bookings extends Resource {
    * @link https://duffel.com/docs/api/bookings/list-bookings
    */
   public list = async (
-    options?: PaginationMeta,
+    options?: PaginationMeta & ListParamsBookings,
   ): Promise<DuffelResponse<StaysBooking[]>> =>
     this.request({ method: 'GET', path: this.path, params: options })
 
@@ -78,11 +78,10 @@ export class Bookings extends Resource {
    * Retrieves a generator of all bookings. The results may be returned in any order.
    * @link https://duffel.com/docs/api/bookings/list-bookings
    */
-  public listWithGenerator = (): AsyncGenerator<
-    DuffelResponse<StaysBooking>,
-    void,
-    unknown
-  > => this.paginatedRequest({ path: this.path })
+  public listWithGenerator = (
+    options?: ListParamsBookings,
+  ): AsyncGenerator<DuffelResponse<StaysBooking>, void, unknown> =>
+    this.paginatedRequest({ path: this.path, params: options })
 
   /**
    * Cancel a booking

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -734,3 +734,10 @@ export interface StaysAccommodationReview {
 export interface StaysAccommodationReviewResponse {
   reviews: Array<StaysAccommodationReview>
 }
+
+export type ListParamsBookings = {
+  /**
+   * Whether to filter bookings matching a given customer user id.
+   */
+  user_id?: string
+}

--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -670,6 +670,11 @@ export interface ListParamsOrders {
    * Whether to filter orders matching a given passenger name record (PNR)
    */
   booking_reference?: string
+
+  /**
+   * Whether to filter orders matching a given customer user id.
+   */
+  user_id?: string
 }
 
 export interface UpdateSingleOrder {


### PR DESCRIPTION
To support the updates to `GET air/orders` and `GET stays/bookings`