### PR TITLE
Pin GitHub Actions to commit SHAs at latest versions

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -6,7 +6,7 @@ jobs:
   auto-approve:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/auto-approve-action@v2
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         if: github.actor == 'duffel-bot'
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .tool-versions
 
@@ -32,7 +32,7 @@ jobs:
         run: echo "dir=$(corepack yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Yarn packages
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .tool-versions
 
@@ -68,7 +68,7 @@ jobs:
         run: echo "dir=$(corepack yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Yarn packages
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -86,12 +86,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .tool-versions
 
@@ -103,7 +103,7 @@ jobs:
         run: echo "dir=$(corepack yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Yarn packages
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .tool-versions
 
@@ -24,7 +24,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(corepack yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -66,7 +66,7 @@ jobs:
       - name: Create Pull Request with updated package files
         id: cpr
         if: steps.initversion.outputs.version != steps.extractver.outputs.extractver
-        uses: peter-evans/create-pull-request@v5.0.3
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.PAT }}
           commit-message: 'ci(release): ${{ steps.extractver.outputs.extractver }}'
@@ -85,7 +85,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
         with:
           token: ${{ secrets.PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to specific commit SHAs for supply chain security
- Update all actions to their latest released versions

| Action | Previous | Updated | SHA |
|--------|----------|---------|-----|
| `hmarr/auto-approve-action` | v2 | v4.0.0 | `f0939ea9` |
| `actions/checkout` | v4 | v6.0.2 | `de0fac2e` |
| `actions/setup-node` | v4 | v6.3.0 | `53b83947` |
| `actions/cache` | v4 | v5.0.4 | `66822842` |
| `peter-evans/create-pull-request` | v5.0.3 | v8.1.0 | `c0f553fe` |
| `peter-evans/enable-pull-request-automerge` | v3 | v3.0.0 | `a660677d` |

## Changelog review

### actions/checkout (v4 → v6) ✅ No impact
- **v5**: Node 20 → 24 runtime (runner ≥ v2.327.1)
- **v6**: Credentials stored in `$RUNNER_TEMP` instead of `.git/config` (runner ≥ v2.329.0)
- Our usage is basic checkout with optional `fetch-depth: 0`. No impact on GitHub-hosted runners.

### actions/setup-node (v4 → v6) ✅ No impact
- **v5**: Auto-caching when `packageManager` field exists in `package.json`; Node 24 runtime
- **v6**: Auto-caching narrowed to npm only (yarn/pnpm must opt in explicitly)
- We use `node-version-file: .tool-versions` with yarn and don't use the `cache` input. Auto-caching won't kick in for yarn.

### actions/cache (v4 → v5) ✅ No impact
- **v5**: Node 20 → 24 runtime. No input/output changes at all.
- We use standard `path`/`key`/`restore-keys` — all unchanged.

### hmarr/auto-approve-action (v2 → v4) ✅ No impact
- **v3**: Node 12 → 16; **v4**: Node 16 → 20. No input/output changes across any version.
- Our `github-token` input works identically.

### peter-evans/create-pull-request (v5 → v8) ✅ No impact
- **v6**: Default `committer`/`author` changed; new `git-token` input
- **v7**: `git-token` renamed to `branch-token`; `pull-request-operation` output returns `"none"` instead of empty on no-op; removed deprecated `PULL_REQUEST_NUMBER` env var
- **v8**: Node 24 runtime
- We explicitly set `committer`/`author` (unaffected by default change), never used `git-token`, use the action output `pull-request-number` not the env var, and our `== 'created'` check correctly handles the new `"none"` value.

### peter-evans/enable-pull-request-automerge (v3 → v3.0.0) ✅ No impact
- Already on v3, now pinned to the exact SHA. No version change.

## Test plan
- [ ] CI passes on this PR (lint, test, commitlint)
- [ ] Verify release workflow runs correctly on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)