### PR TITLE
feat(stays): add instant_payment to search params

### DIFF
--- a/src/Stays/Stays.spec.ts
+++ b/src/Stays/Stays.spec.ts
@@ -25,6 +25,7 @@ describe('Stays', () => {
       rooms: 1,
       mobile: false,
       free_cancellation_only: false,
+      instant_payment: null,
     }
 
     nock(/(.*)/)

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -713,6 +713,11 @@ interface CommonStaysSearchParams {
   guests: Array<Guest>
   mobile?: boolean
   free_cancellation_only?: boolean
+  /**
+   * Preview: when `true`, only pay-now (Duffel/source) rates; when `false`, only pay-at-property;
+   * when `null` or omitted, all rates. See Duffel Stays search API schema.
+   */
+  instant_payment?: boolean | null
 }
 
 export type LocationParams = {


### PR DESCRIPTION
### What's here?

Adds a new search parameter in stays that's in the phases of being tried out for a use case.