### PR TITLE
ci: run on pull requests instead of all pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Restrict push triggers to main and add a pull_request trigger so CI runs on PRs from fork/branch pushes without duplicating runs for branches with open PRs.

See: https://github.com/orgs/community/discussions/119459#discussioncomment-9180402

TSP-1364