### PR TITLE
feat(stays): add chain_id support and NegotiatedRates module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duffel/api",
-  "version": "4.25.0",
+  "version": "4.26.0",
   "description": "Javascript client library for the Duffel API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Stays/NegotiatedRates/NegotiatedRates.spec.ts
+++ b/src/Stays/NegotiatedRates/NegotiatedRates.spec.ts
@@ -1,0 +1,172 @@
+import nock from 'nock'
+import { Duffel } from '../../index'
+import { MOCK_NEGOTIATED_RATE } from '../mocks'
+import {
+  StaysNegotiatedRateCreatePayload,
+  StaysNegotiatedRateUpdatePayload,
+} from '../StaysTypes'
+
+const duffel = new Duffel({ token: 'mockToken' })
+
+describe('Stays/NegotiatedRates', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should post to /stays/negotiated_rates when `create` is called with chain_id', async () => {
+    const negotiatedRateWithChain = {
+      ...MOCK_NEGOTIATED_RATE,
+      chain_id: 'chn_0000B6QFxO9EOY5cqw5kYK',
+      accommodation_ids: null,
+    }
+    const mockResponse = { data: negotiatedRateWithChain }
+    const createPayload: StaysNegotiatedRateCreatePayload = {
+      rate_access_code: 'DUFFEL',
+      display_name: '2025 Negotiated Rate',
+      chain_id: 'chn_0000B6QFxO9EOY5cqw5kYK',
+    }
+
+    nock(/(.*)/)
+      .post('/stays/negotiated_rates', (body) => {
+        expect(body.data).toEqual(createPayload)
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.negotiatedRates.create(createPayload)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should post to /stays/negotiated_rates when `create` is called with accommodation_ids', async () => {
+    const mockResponse = { data: MOCK_NEGOTIATED_RATE }
+    const createPayload: StaysNegotiatedRateCreatePayload = {
+      rate_access_code: 'DUFFEL',
+      display_name: '2025 Negotiated Rate',
+      accommodation_ids: ['acc_0000AWr2VsUNIF1Vl91xg0'],
+    }
+
+    nock(/(.*)/)
+      .post('/stays/negotiated_rates', (body) => {
+        expect(body.data).toEqual(createPayload)
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.negotiatedRates.create(createPayload)
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should get to /stays/negotiated_rates/{id} when `get` is called', async () => {
+    const mockResponse = { data: MOCK_NEGOTIATED_RATE }
+
+    nock(/(.*)/)
+      .get(`/stays/negotiated_rates/${MOCK_NEGOTIATED_RATE.id}`)
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.negotiatedRates.get(
+      MOCK_NEGOTIATED_RATE.id,
+    )
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should patch to /stays/negotiated_rates/{id} when `update` is called', async () => {
+    const updatedRate = {
+      ...MOCK_NEGOTIATED_RATE,
+      display_name: 'Updated Negotiated Rate',
+    }
+    const mockResponse = { data: updatedRate }
+    const updatePayload: StaysNegotiatedRateUpdatePayload = {
+      display_name: 'Updated Negotiated Rate',
+    }
+
+    nock(/(.*)/)
+      .patch(`/stays/negotiated_rates/${MOCK_NEGOTIATED_RATE.id}`, (body) => {
+        expect(body.data).toEqual(updatePayload)
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.negotiatedRates.update(
+      MOCK_NEGOTIATED_RATE.id,
+      updatePayload,
+    )
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should patch to /stays/negotiated_rates/{id} when `update` is called with chain_id', async () => {
+    const updatedRate = {
+      ...MOCK_NEGOTIATED_RATE,
+      chain_id: 'chn_0000B6QFxO9EOY5cqw5kYK',
+      accommodation_ids: null,
+    }
+    const mockResponse = { data: updatedRate }
+    const updatePayload: StaysNegotiatedRateUpdatePayload = {
+      chain_id: 'chn_0000B6QFxO9EOY5cqw5kYK',
+    }
+
+    nock(/(.*)/)
+      .patch(`/stays/negotiated_rates/${MOCK_NEGOTIATED_RATE.id}`, (body) => {
+        expect(body.data).toEqual(updatePayload)
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.negotiatedRates.update(
+      MOCK_NEGOTIATED_RATE.id,
+      updatePayload,
+    )
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should get to /stays/negotiated_rates when `list` is called', async () => {
+    const mockResponse = { data: [MOCK_NEGOTIATED_RATE] }
+
+    nock(/(.*)/).get('/stays/negotiated_rates').reply(200, mockResponse)
+
+    const response = await duffel.stays.negotiatedRates.list()
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should get a page of negotiated rates when `list` is called with pagination params', async () => {
+    const mockResponse = { data: [MOCK_NEGOTIATED_RATE] }
+
+    nock(/(.*)/)
+      .get('/stays/negotiated_rates')
+      .query((queryObject) => {
+        expect(queryObject.limit).toEqual('1')
+        return true
+      })
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.negotiatedRates.list({ limit: 1 })
+    expect(response.data).toEqual(mockResponse.data)
+  })
+
+  it('should get all negotiated rates paginated', async () => {
+    nock(/(.*)/)
+      .get('/stays/negotiated_rates')
+      .reply(200, {
+        data: [MOCK_NEGOTIATED_RATE],
+        meta: { limit: 1, before: null, after: null },
+      })
+
+    const response = duffel.stays.negotiatedRates.listWithGenerator()
+
+    for await (const page of response) {
+      expect(page.data.id).toBe(MOCK_NEGOTIATED_RATE.id)
+    }
+  })
+
+  it('should delete to /stays/negotiated_rates/{id} when `delete` is called', async () => {
+    const mockResponse = { data: MOCK_NEGOTIATED_RATE }
+
+    nock(/(.*)/)
+      .delete(`/stays/negotiated_rates/${MOCK_NEGOTIATED_RATE.id}`)
+      .reply(200, mockResponse)
+
+    const response = await duffel.stays.negotiatedRates.delete(
+      MOCK_NEGOTIATED_RATE.id,
+    )
+    expect(response.data).toEqual(mockResponse.data)
+  })
+})

--- a/src/Stays/NegotiatedRates/NegotiatedRates.ts
+++ b/src/Stays/NegotiatedRates/NegotiatedRates.ts
@@ -1,0 +1,91 @@
+import { Client } from '../../Client'
+import {
+  StaysNegotiatedRate,
+  StaysNegotiatedRateCreatePayload,
+  StaysNegotiatedRateUpdatePayload,
+} from '../StaysTypes'
+import { Resource } from '../../Resource'
+import { DuffelResponse, PaginationMeta } from '../../types'
+
+export class NegotiatedRates extends Resource {
+  /**
+   * Endpoint path
+   */
+  path: string
+
+  constructor(client: Client) {
+    super(client)
+    this.path = 'stays/negotiated_rates'
+  }
+
+  /**
+   * Create a negotiated rate.
+   * You must provide either chain_id or accommodation_id, but not both.
+   * @param {object} payload - The negotiated rate payload
+   */
+  public create = async (
+    payload: StaysNegotiatedRateCreatePayload,
+  ): Promise<DuffelResponse<StaysNegotiatedRate>> =>
+    this.request({
+      method: 'POST',
+      path: this.path,
+      data: payload,
+    })
+
+  /**
+   * Get a negotiated rate by ID
+   * @param {string} id - The ID of the negotiated rate
+   */
+  public get = async (
+    id: string,
+  ): Promise<DuffelResponse<StaysNegotiatedRate>> =>
+    this.request({
+      method: 'GET',
+      path: `${this.path}/${id}`,
+    })
+
+  /**
+   * Update a negotiated rate
+   * @param {string} id - The ID of the negotiated rate
+   * @param {object} payload - The update payload
+   */
+  public update = async (
+    id: string,
+    payload: StaysNegotiatedRateUpdatePayload,
+  ): Promise<DuffelResponse<StaysNegotiatedRate>> =>
+    this.request({
+      method: 'PATCH',
+      path: `${this.path}/${id}`,
+      data: payload,
+    })
+
+  /**
+   * List negotiated rates
+   * @param {Object} [options] - Pagination options (optional: limit, after, before)
+   */
+  public list = async (
+    options?: PaginationMeta,
+  ): Promise<DuffelResponse<StaysNegotiatedRate[]>> =>
+    this.request({ method: 'GET', path: this.path, params: options })
+
+  /**
+   * Retrieves a generator of all negotiated rates. The results may be returned in any order.
+   */
+  public listWithGenerator = (): AsyncGenerator<
+    DuffelResponse<StaysNegotiatedRate>,
+    void,
+    unknown
+  > => this.paginatedRequest({ path: this.path })
+
+  /**
+   * Delete a negotiated rate
+   * @param {string} id - The ID of the negotiated rate
+   */
+  public delete = async (
+    id: string,
+  ): Promise<DuffelResponse<StaysNegotiatedRate>> =>
+    this.request({
+      method: 'DELETE',
+      path: `${this.path}/${id}`,
+    })
+}

--- a/src/Stays/NegotiatedRates/index.ts
+++ b/src/Stays/NegotiatedRates/index.ts
@@ -1,0 +1,1 @@
+export * from './NegotiatedRates'

--- a/src/Stays/Stays.ts
+++ b/src/Stays/Stays.ts
@@ -6,6 +6,7 @@ import { Accommodation } from './Accommodation'
 import { Brands } from './Brands'
 import { LoyaltyProgrammes } from './LoyaltyProgrammes'
 import { Bookings } from './Bookings'
+import { NegotiatedRates } from './NegotiatedRates'
 import { Quotes } from './Quotes'
 import { SearchResults } from './SearchResults'
 
@@ -18,6 +19,7 @@ export class Stays extends Resource {
   public accommodation: Accommodation
   public loyaltyProgrammes: LoyaltyProgrammes
   public brands: Brands
+  public negotiatedRates: NegotiatedRates
   public searchResults: SearchResults
   public quotes: Quotes
   public bookings: Bookings
@@ -29,6 +31,7 @@ export class Stays extends Resource {
     this.accommodation = new Accommodation(client)
     this.brands = new Brands(client)
     this.loyaltyProgrammes = new LoyaltyProgrammes(client)
+    this.negotiatedRates = new NegotiatedRates(client)
     this.searchResults = new SearchResults(client)
     this.quotes = new Quotes(client)
     this.bookings = new Bookings(client)

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -299,7 +299,12 @@ export interface StaysAmenity {
 
 export interface StaysChain {
   /**
-   * The hotel chain’s name
+   * Duffel ID for this chain
+   */
+  id: string
+
+  /**
+   * The hotel chain's name
    */
   name: string
 }
@@ -802,4 +807,146 @@ export type ListParamsBookings = {
    * Whether to filter bookings matching a given customer user id.
    */
   user_id?: string
+}
+
+/**
+ * A negotiated rate that enables passing rate access codes for stays accommodation.
+ * Can be associated with either a chain or specific accommodations, but not both.
+ */
+export interface StaysNegotiatedRate {
+  /**
+   * The ID of the Negotiated Rate
+   *
+   * Example: "nre_0000AvtkNoC81yBytDM9PE"
+   */
+  id: string
+
+  /**
+   * The rate access code to be utilised when using this negotiated rate
+   *
+   * Example: "DUFFEL"
+   */
+  rate_access_code: string
+
+  /**
+   * The display name of the negotiated rate
+   *
+   * Example: "2025 Negotiated Rate"
+   */
+  display_name: string
+
+  /**
+   * Whether this negotiated rate is for live mode. When false, it is for test mode
+   *
+   * Example: false
+   */
+  live_mode: boolean
+
+  /**
+   * The ID of the hotel chain this negotiated rate is valid for.
+   * Mutually exclusive with accommodation_ids.
+   *
+   * Example: "chn_0000B6QFxO9EOY5cqw5kYK"
+   */
+  chain_id: string | null
+
+  /**
+   * The accommodation ids this negotiated rate is valid for use with.
+   * Mutually exclusive with chain_id.
+   *
+   * Example: ["acc_0000AWr2VsUNIF1Vl91xg0"]
+   */
+  accommodation_ids: string[] | null
+}
+
+/**
+ * Payload for creating a negotiated rate associated with a chain.
+ * You must provide either chain_id or accommodation_ids, but not both.
+ */
+export interface StaysNegotiatedRateCreatePayloadWithChain {
+  /**
+   * The rate access code to be utilised when using this negotiated rate
+   *
+   * Example: "DUFFEL"
+   */
+  rate_access_code: string
+
+  /**
+   * The display name of the negotiated rate
+   *
+   * Example: "2025 Negotiated Rate"
+   */
+  display_name: string
+
+  /**
+   * The ID of the hotel chain this negotiated rate is valid for
+   *
+   * Example: "chn_0000B6QFxO9EOY5cqw5kYK"
+   */
+  chain_id: string
+}
+
+/**
+ * Payload for creating a negotiated rate associated with accommodations.
+ * You must provide either chain_id or accommodation_ids, but not both.
+ */
+export interface StaysNegotiatedRateCreatePayloadWithAccommodations {
+  /**
+   * The rate access code to be utilised when using this negotiated rate
+   *
+   * Example: "DUFFEL"
+   */
+  rate_access_code: string
+
+  /**
+   * The display name of the negotiated rate
+   *
+   * Example: "2025 Negotiated Rate"
+   */
+  display_name: string
+
+  /**
+   * The accommodation ids this negotiated rate is valid for use with
+   *
+   * Example: ["acc_0000AWr2VsUNIF1Vl91xg0"]
+   */
+  accommodation_ids: string[]
+}
+
+/**
+ * Payload for creating a negotiated rate.
+ * You must provide either chain_id or accommodation_ids, but not both.
+ */
+export type StaysNegotiatedRateCreatePayload =
+  | StaysNegotiatedRateCreatePayloadWithChain
+  | StaysNegotiatedRateCreatePayloadWithAccommodations
+
+/**
+ * Payload for updating a negotiated rate.
+ * You can update the display_name and change the association to chain_id or accommodation_ids.
+ * If updating the association, you must provide only one of chain_id or accommodation_ids.
+ */
+export interface StaysNegotiatedRateUpdatePayload {
+  /**
+   * The display name of the negotiated rate
+   *
+   * Example: "2025 Negotiated Rate"
+   */
+  display_name?: string
+
+  /**
+   * The ID of the hotel chain this negotiated rate is valid for.
+   * Setting this will remove any existing accommodation_ids association.
+   *
+   * Example: "chn_0000B6QFxO9EOY5cqw5kYK"
+   */
+  chain_id?: string
+
+  /**
+   * The accommodation ids this negotiated rate is valid for use with.
+   * Setting this will remove any existing chain_id association.
+   *
+   * Example: ["acc_0000AWr2VsUNIF1Vl91xg0"]
+   */
+  accommodation_ids?: string[]
 }

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -5,7 +5,9 @@ import {
   StaysAccommodationReviewResponse,
   StaysAccommodationSuggestion,
   StaysBooking,
+  StaysChain,
   StaysLoyaltyProgramme,
+  StaysNegotiatedRate,
   StaysQuote,
   StaysSearchResult,
 } from './StaysTypes'
@@ -14,6 +16,11 @@ import { StaysBookingPayload } from './Bookings/Bookings'
 export const MOCK_BRAND: StaysAccommodationBrand = {
   id: 'bra_DQPneLbCejxRuxAqD7amaW',
   name: 'The Ritz-Carlton',
+}
+
+export const MOCK_CHAIN: StaysChain = {
+  id: 'chn_0000AWr2VsUNIF1Vl91xg0',
+  name: 'Marriott International',
 }
 
 export const MOCK_ACCOMMODATION: StaysAccommodation = {
@@ -164,9 +171,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
     instructions: 'Key is at the property. Collect from the lock box.',
   },
   brand: MOCK_BRAND,
-  chain: {
-    name: 'Marriott International',
-  },
+  chain: MOCK_CHAIN,
   supported_loyalty_programme: 'duffel_hotel_group_rewards',
 }
 
@@ -300,3 +305,12 @@ export const MOCK_LOYALTY_PROGRAMMES: StaysLoyaltyProgramme[] = [
       'https://assets.duffel.com/img/stays/loyalty-programmes/transparent-logo/duffel_hotel_group_rewards.png',
   },
 ]
+
+export const MOCK_NEGOTIATED_RATE: StaysNegotiatedRate = {
+  id: 'nre_0000AvtkNoC81yBytDM9PE',
+  rate_access_code: 'DUFFEL',
+  display_name: '2025 Negotiated Rate',
+  live_mode: false,
+  chain_id: null,
+  accommodation_ids: ['acc_0000AWr2VsUNIF1Vl91xg0'],
+}


### PR DESCRIPTION
## Summary

- Add `id` field to `StaysChain` interface to support chain identification in accommodation responses
- Add new `NegotiatedRates` module with full CRUD operations based on [API docs](https://duffel.com/docs/api/v2/negotiated-rates):
  - `create` - with either `chain_id` or `accommodation_ids` (mutually exclusive)
  - `get`, `update`, `list`, `listWithGenerator`, `delete`
- Add TypeScript types for negotiated rates: `StaysNegotiatedRate`, `StaysNegotiatedRateCreatePayload`, `StaysNegotiatedRateUpdatePayload`
- Add `MOCK_CHAIN` and `MOCK_NEGOTIATED_RATE` test fixtures

## Changes

| File | Change |
|------|--------|
| `StaysTypes.ts` | Added `id` to `StaysChain`, added all negotiated rate types |
| `Stays.ts` | Added `negotiatedRates` resource |
| `NegotiatedRates/` | New module with class, index, and spec (9 tests) |
| `mocks.ts` | Added `MOCK_CHAIN`, `MOCK_NEGOTIATED_RATE`, updated `MOCK_ACCOMMODATION` |

## Test plan

- [x] All 33 Stays tests pass
- [x] 9 new NegotiatedRates tests cover create, get, update, list, listWithGenerator, delete operations
- [x] Tests cover both `chain_id` and `accommodation_ids` variants for create/update


Made with [Cursor](https://cursor.com)