### PR TITLE
ci: stop re-shallowing origin/main in commitlint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,5 @@ jobs:
       - name: Install dependencies
         run: corepack yarn install --immutable
 
-      - name: Fetch main for commitlint
-        run: git fetch origin main --depth=1
-
       - name: Run commitlint
         run: corepack yarn commitlint --from origin/main


### PR DESCRIPTION
## Problem

The `Commitlint` job fails on PRs whose branch is behind `main`, reporting errors on **old, pre-convention commits** (e.g. `chore(release): 1.8.0`, `[STAYS-521] Add cancel booking to Stays`) rather than the PR's own commits.

## Root cause

The job checks out with `fetch-depth: 0` (full history), but then runs:

```yaml
- name: Fetch main for commitlint
  run: git fetch origin main --depth=1
```

That `--depth=1` fetch **re-shallows** the `origin/main` ref to a single commit, throwing away the full history `fetch-depth: 0` had just provided. With no common ancestor in the local history, `commitlint --from origin/main` can't compute the merge-base and instead lints the **entire repo history** — failing on legacy commits.

## Fix

Remove the redundant shallow-fetch step. `fetch-depth: 0` already makes `origin/main` available with full history, so the merge-base resolves and commitlint lints only the PR's commits.

Seen on #1165, where the Commitlint check failed on unrelated historical commits.

[STAYS-521]: https://duffel.atlassian.net/browse/STAYS-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ