### PR TITLE
feat(stays): support negotiated rates in search request and results

### DIFF
--- a/src/Stays/Stays.spec.ts
+++ b/src/Stays/Stays.spec.ts
@@ -119,4 +119,28 @@ describe('Stays', () => {
     const response = await duffel.stays.search(mockSearchParams)
     expect(response.data).toEqual(mockResponse.data)
   })
+
+  it('should send `negotiated_rate_ids` and surface negotiated rate fields in the response', async () => {
+    const mockResponse = { data: { results: [MOCK_SEARCH_RESULT] } }
+    const mockSearchParams: StaysSearchParams = {
+      accommodation: {
+        ids: ['acc_12345'],
+        fetch_rates: true,
+      },
+      check_in_date: '2023-10-20',
+      check_out_date: '2023-10-24',
+      guests: [{ type: 'adult' }, { type: 'adult' }],
+      rooms: 1,
+      negotiated_rate_ids: ['nre_0000AvtkNoC81yBytDM9PE'],
+    }
+
+    nock(/(.*)/)
+      .post('/stays/search', (body) => {
+        expect(body.data).toEqual(mockSearchParams)
+        return true
+      })
+      .reply(200, mockResponse)
+    const response = await duffel.stays.search(mockSearchParams)
+    expect(response.data).toEqual(mockResponse.data)
+  })
 })

--- a/src/Stays/StaysTypes.ts
+++ b/src/Stays/StaysTypes.ts
@@ -238,6 +238,13 @@ export interface StaysRate {
    * Example: "Best Available Rate"
    */
   name: string | null
+
+  /**
+   * The ID of the negotiated rate (e.g. `nre_…`) that this rate was matched to,
+   * when the rate is returned as a result of a negotiated rate passed in the search.
+   * Returned when possible at fetch rates, quote and booking.
+   */
+  negotiated_rate_id?: string | null
 }
 
 export interface StaysRoomRate extends StaysRate {
@@ -733,6 +740,13 @@ interface CommonStaysSearchParams {
    * when `null` or omitted, all rates. See Duffel Stays search API schema.
    */
   instant_payment?: boolean | null
+
+  /**
+   * A list of negotiated rate IDs (e.g. `nre_…`) to apply to this search.
+   * Any eligible negotiated rates are returned alongside the standard public rates.
+   * Matching is best-effort: a supported negotiated rate is not guaranteed to be available.
+   */
+  negotiated_rate_ids?: string[]
 }
 
 export type LocationParams = {
@@ -779,6 +793,16 @@ export interface StaysSearchResult {
   cheapest_rate_public_currency: string
   cheapest_rate_due_at_accommodation_amount: string | null
   cheapest_rate_due_at_accommodation_currency: string | null
+  /**
+   * The negotiated rates that were searched for and are supported by this result.
+   * A supported negotiated rate does not guarantee that a negotiated rate is available.
+   */
+  supported_negotiated_rates?: Array<{
+    /** The ID of the negotiated rate (e.g. `nre_…`). */
+    id: string
+    /** The display name of the negotiated rate. */
+    display_name: string
+  }>
   /**
    * The ISO 8601 date and time at which the search result will expire
    */

--- a/src/Stays/mocks.ts
+++ b/src/Stays/mocks.ts
@@ -74,6 +74,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
           estimated_commission_currency: 'GBP',
           expires_at: '2023-03-28T12:00:00Z',
           code: null,
+          negotiated_rate_id: null,
           description: null,
           name: 'Best Available Rate',
         },
@@ -111,6 +112,7 @@ export const MOCK_ACCOMMODATION: StaysAccommodation = {
           estimated_commission_currency: 'GBP',
           expires_at: '2023-03-28T12:00:00Z',
           code: 'ABC',
+          negotiated_rate_id: 'nre_0000AvtkNoC81yBytDM9PE',
           description: 'ABC - Free cancellation up to 1 hour after booking',
           name: 'Refundable Rate',
         },
@@ -218,6 +220,9 @@ export const MOCK_SEARCH_RESULT: StaysSearchResult = {
   cheapest_rate_base_currency: 'GBP',
   cheapest_rate_due_at_accommodation_amount: '39.95',
   cheapest_rate_due_at_accommodation_currency: 'GBP',
+  supported_negotiated_rates: [
+    { id: 'nre_0000AvtkNoC81yBytDM9PE', display_name: '2025 Negotiated Rate' },
+  ],
   expires_at: '2023-03-28T12:00:00Z',
 }
 


### PR DESCRIPTION
## Summary

Adds type support for Duffel Stays negotiated rates
(https://duffel.com/docs/guides/negotiated-rates) to the Stays **search**
request and response.

The negotiated-rate resource CRUD (`stays.negotiatedRates.*`) already exists in
the SDK, but the search-side fields that _apply_ and _surface_ those rates are
not yet typed. This PR closes that gap.

## Changes

- `StaysSearchParams` (via `CommonStaysSearchParams`): add optional top-level
  `negotiated_rate_ids?: string[]` — passed on a stays search to apply eligible
  negotiated rates.
- `StaysSearchResult`: add optional `supported_negotiated_rates?`
  (`{ id; display_name }[]`) — the negotiated rates that were searched for and
  are supported by the result.
- `StaysRate`: add optional `negotiated_rate_id?: string | null` — the
  negotiated rate a returned rate was matched to (surfaced when fetching rates);
  inherited by `StaysRoomRate`.
- Mocks + a `Stays.search` spec covering the round-trip.

## Notes

- All additions are optional and additive — no breaking changes.
- Field names follow the Stays search API / negotiated-rates guide.
- Scoped to the search surface. Echoing `negotiated_rate_id` on the quote /
  booking resources can be a follow-up (those SDK types are flat and would need
  their own field).

## Testing

- `yarn build:test` (tsc + rollup) and `yarn test` pass.
- New test asserts `negotiated_rate_ids` is sent in the search body and the
  negotiated response fields round-trip.
