### PR TITLE
TSP-1694: add Order content type

### DIFF
--- a/src/booking/Orders/OrdersTypes.ts
+++ b/src/booking/Orders/OrdersTypes.ts
@@ -473,6 +473,8 @@ export interface OrderPayment {
   currency: string
 }
 
+export type OrderContent = 'managed' | 'self_managed'
+
 export interface Order {
   /**
    * The amount of tax payable on the order for all the flights booked
@@ -541,6 +543,11 @@ export interface Order {
    * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) datetime at which the order was created
    */
   created_at: string
+
+  /**
+   * The content management type for this order
+   */
+  content: OrderContent
 
   /**
    * The [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) datetime at which the order was cancelled, if it has been cancelled

--- a/src/booking/Orders/mockOrders.ts
+++ b/src/booking/Orders/mockOrders.ts
@@ -274,6 +274,7 @@ export const mockOrder: Order = {
     },
   ],
   created_at: '2020-04-11T15:48:11.642Z',
+  content: 'self_managed',
   conditions: {
     refund_before_departure: {
       penalty_currency: 'GBP',
@@ -463,6 +464,7 @@ export const mockOnHoldOrders: Order[] = [
     id: 'ord_0000A6GioOO1UDbjb7nIi8',
     documents: [],
     created_at: '2021-04-15T11:12:53.465121Z',
+    content: 'managed',
     conditions: {
       refund_before_departure: null,
       change_before_departure: null,
@@ -644,6 +646,7 @@ export const mockOnHoldOrders: Order[] = [
     id: 'ord_0000A6GiZRU4WXtdZJrivT',
     documents: [],
     created_at: '2021-04-15T11:10:11.352074Z',
+    content: 'self_managed',
     conditions: {
       refund_before_departure: null,
       change_before_departure: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add the missing `content` attribute to the `Order` interface
- model its documented values as `managed | self_managed`
- update typed Order fixtures to cover both values

## Testing
- `corepack yarn test src/booking/Orders/Orders.spec.ts`
- `corepack yarn build:test`
- `corepack yarn eslint src/booking/Orders/OrdersTypes.ts src/booking/Orders/mockOrders.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://duffel.slack.com/archives/C05GANU3TB6/p1785421286484479?thread_ts=1785421286.484479&cid=C05GANU3TB6)

<div><a href="https://cursor.com/agents/bc-f72f8808-f1f8-51a9-aaa0-5453cd79e1a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f72f8808-f1f8-51a9-aaa0-5453cd79e1a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

