### PR TITLE
fix(ci): pin npm to v11 in release to avoid Node 20 EBADENGINE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,10 @@ jobs:
 
       # Trusted publishing requires npm CLI >= 11.5.1, which is newer than the
       # version bundled with Node 20. semantic-release publishes via the npm CLI.
+      # Pin to npm 11 (not @latest): npm 12+ requires Node >= 22 and would fail
+      # with EBADENGINE on the Node 20 runtime defined in .tool-versions.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,17 @@ jobs:
           node-version-file: .tool-versions
 
       # Trusted publishing requires npm CLI >= 11.5.1, which is newer than the
-      # version bundled with Node 20. semantic-release publishes via the npm CLI.
-      # Pin to npm 11 (not @latest): npm 12+ requires Node >= 22 and would fail
-      # with EBADENGINE on the Node 20 runtime defined in .tool-versions.
+      # version bundled with Node 20 (and Node 22, which still ships npm 10.x).
+      # semantic-release publishes via the npm CLI, so we upgrade it here.
+      #
+      # We deliberately pin to a range (npm@^11.5.1) instead of npm@latest.
+      # npm@latest is what broke this pipeline: npm 12 dropped Node 20 support,
+      # so the floating tag started installing an EBADENGINE-incompatible npm on
+      # the Node runtime defined in .tool-versions. Keep this pin even after
+      # upgrading to Node 22: a future npm major could likewise drop the current
+      # Node line, and pinning keeps releases reproducible instead of silently
+      # tracking the newest npm. Bump this range intentionally alongside any Node
+      # bump.
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@^11.5.1
 


### PR DESCRIPTION
## Problem

The [Release to NPM workflow](https://github.com/duffelhq/duffel-api-javascript/actions/runs/34456986668/job/102805570338) is failing at the **Upgrade npm for trusted publishing** step:

```
npm error code EBADENGINE
npm error engine Not compatible with your version of node/npm: npm@12.0.2
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.19.4"}
```

The step runs `npm install -g npm@latest`. npm recently released **12.x**, which requires Node >= 22. The release job runs on Node 20 (`.tool-versions` = `nodejs 20.19.4`), so the floating `@latest` tag now pulls an incompatible npm.

## Fix

Pin to `npm@^11.5.1`. npm 11 still satisfies the trusted-publishing requirement (npm >= 11.5.1) and remains compatible with Node 20.

Alternative (not taken here): bump the runtime to Node 22+, which is a broader change affecting CI and local dev.

Made with [Cursor](https://cursor.com)